### PR TITLE
Fix talents deduplication return

### DIFF
--- a/src/lib/nullGetTalents.ts
+++ b/src/lib/nullGetTalents.ts
@@ -13,7 +13,8 @@ export interface NullTalent {
 }
 
 /**
- * Method that takes WCL classId and specId and returns a list of talents from Raidbots static talents data
+ * Method that takes WCL classId and specId and returns a deduplicated list of talents
+ * from Raidbots static talents data
  */
 export async function nullGetTalents(
     /** According to WCL */
@@ -77,7 +78,7 @@ export async function nullGetTalents(
         }
     });
 
-    return nullTalents;
+    return deduplicated;
 }
 
 function talentNodesToNullTalents(talentNodes: LiteTalentNode[]): NullTalent[] {


### PR DESCRIPTION
## Summary
- return deduplicated list from `nullGetTalents`
- clarify JSDoc about deduplicated return

## Testing
- `npm run lint`
- `npm run test-ci` *(fails: No tests found)*
- `npm run build` *(fails: ENETUNREACH while fetching raidbots data)*

------
https://chatgpt.com/codex/tasks/task_e_6840280e63b48333843e5dff53d0749a