### PR TITLE
Fix default type for item filter params

### DIFF
--- a/src/lib/Params.ts
+++ b/src/lib/Params.ts
@@ -30,7 +30,8 @@ interface ParamTypeTalentFilter {
 interface ParamTypeItemFilters {
     name: string;
     type: "itemFilters";
-    default: TalentFilterConfig[] | null;
+    // Defaults to an ItemFilterConfig[] array
+    default: ItemFilterConfig[] | null;
 }
 
 function isParamTypeString(paramType: ParamType): paramType is ParamTypeString {


### PR DESCRIPTION
## Summary
- correct `ParamTypeItemFilters.default` type to `ItemFilterConfig[]`

## Testing
- `npm run lint-fix`
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68402812993083338b7f5c4dd569ffd4