### PR TITLE
Add params utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "postlint-fix": "npm run prettier-fix",
         "prettier-fix": "prettier **/*.{md,yml,yaml,json} --ignore-path .gitignore --write",
         "lint-staged": "lint-staged",
-        "test": "jest --watch",
+        "test": "jest",
         "test-ci": "jest --ci"
     },
     "dependencies": {

--- a/src/lib/__tests__/Params.test.ts
+++ b/src/lib/__tests__/Params.test.ts
@@ -1,0 +1,49 @@
+import { parseParams, toParams } from "../Params";
+
+describe("Params utils", () => {
+    test("parseParams returns defaults when params missing", () => {
+        const parsed = parseParams(new URLSearchParams());
+        expect(parsed).toEqual({
+            region: null,
+            zone: 42,
+            encounter: 3009,
+            difficulty: 5,
+            partition: null,
+            metric: "dps",
+            classId: null,
+            specId: null,
+            pages: [1],
+            talents: [],
+            itemFilters: [],
+        });
+    });
+
+    test("toParams and parseParams round trip", () => {
+        const params = {
+            region: "US",
+            zone: 1,
+            encounter: 2,
+            difficulty: 3,
+            partition: 4,
+            metric: "hps",
+            classId: 5,
+            specId: 6,
+            pages: [7, 8],
+            talents: [{ name: "a", talentId: "b" }],
+            itemFilters: [
+                {
+                    name: "helm",
+                    id: "1",
+                    permanentEnchant: "2",
+                    temporaryEnchant: "3",
+                    bonusId: "4",
+                    gemId: "5",
+                },
+            ],
+        } as const;
+
+        const sp = toParams(params);
+        const roundTripped = parseParams(sp);
+        expect(roundTripped).toEqual(params);
+    });
+});


### PR DESCRIPTION
## Summary
- add tests for `parseParams` and `toParams`
- run Jest without watch mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68402814b6d483338d73ffc2180fdb54