### PR TITLE
Fix item name input blur

### DIFF
--- a/src/components/ItemPicker/ItemPicker.tsx
+++ b/src/components/ItemPicker/ItemPicker.tsx
@@ -54,13 +54,13 @@ export default function ItemPicker({
         <div className={twMerge(className)} {...props}>
             {localFilters.map((itemFilter, i) => (
                 <ItemFilter
-                    key={`${itemFilter.name}`}
+                    key={i}
                     itemFilter={itemFilter}
                     itemFilterChange={(e, apply) => {
                         const newFilters = [
-                            ...itemFilters.slice(0, i),
+                            ...localFilters.slice(0, i),
                             ...(e == null ? [] : [e]),
-                            ...itemFilters.slice(i + 1),
+                            ...localFilters.slice(i + 1),
                         ];
 
                         setLocalFilters(newFilters);
@@ -68,7 +68,7 @@ export default function ItemPicker({
                             updateUrl(newFilters);
                         }
                     }}
-                    autoFocus={autofocus}
+                    autofocus={autofocus}
                 />
             ))}
             <div className="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- keep ItemFilter component mounted when typing by using a stable key
- update local state when editing item filter
- pass autofocus correctly

## Testing
- `npm run lint-fix`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_684030fb492c83338bec29c7912c45fa