### PR TITLE
fix spec lookup error message

### DIFF
--- a/src/lib/nullGetTalents.ts
+++ b/src/lib/nullGetTalents.ts
@@ -32,7 +32,7 @@ export async function nullGetTalents(
 
             if (spec == null) {
                 throw new Error(
-                    `Could not find spec with id ${specId} for class ${name}`,
+                    `Could not find spec with id ${specId} for class ${klass.name}`,
                 );
             }
 


### PR DESCRIPTION
## Summary
- fix error text in `nullGetTalents` when failing to find a spec

## Testing
- `npm run lint-fix`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6840c4ea859c83339a2e706de9d1a936