### PR TITLE
Add test for default param omission

### DIFF
--- a/src/lib/__tests__/Params.test.ts
+++ b/src/lib/__tests__/Params.test.ts
@@ -46,4 +46,9 @@ describe("Params utils", () => {
         const roundTripped = parseParams(sp);
         expect(roundTripped).toEqual(params);
     });
+
+    test("toParams omits defaults", () => {
+        const sp = toParams(parseParams(new URLSearchParams()));
+        expect(sp.toString()).toBe("");
+    });
 });


### PR DESCRIPTION
## Summary
- verify that `toParams` omits defaults when given parsed empty params

## Testing
- `npm run lint-fix`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6840c4f66ce08333af6f045c5a311284