### PR TITLE
Update caching

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { isNotNull } from "^/lib/utils";
 import { getClasses } from "^/lib/wcl/classes";
 import { getZones } from "^/lib/wcl/zones";
 
-export const revalidate = 1800; // 30 minutes
+// This page is dynamic, so caching would be ignored. Remove the setting.
 
 interface HomeProps {
     searchParams: Promise<RawParams>;

--- a/src/lib/wcl/wclFetch.ts
+++ b/src/lib/wcl/wclFetch.ts
@@ -19,7 +19,6 @@ async function getWclToken() {
                 ).toString("base64")}`,
             },
             body: new URLSearchParams({ grant_type: "client_credentials" }),
-            cache: "force-cache",
         }),
     );
 
@@ -39,7 +38,6 @@ async function getWclToken() {
 export async function wclFetch<T>(
     query: string,
     variables?: Record<string, unknown>,
-    cache: RequestCache = "force-cache",
 ): Promise<T> {
     const token = await getWclToken();
 
@@ -54,15 +52,13 @@ export async function wclFetch<T>(
                 query,
                 ...(variables && { variables }),
             }),
-            next: { revalidate: 1800 },
-            cache,
+            next: { revalidate: 18000 },
         }),
     );
 
     console.log("wclFetch", {
         time,
         query: /query (\w+)/.exec(query)?.[1],
-        requestedCache: cache,
     });
 
     const body: {


### PR DESCRIPTION
## Summary
- remove unused page revalidate value
- remove ineffective POST cache directives
- extend revalidate for wcl fetch to 5 hours

## Testing
- `npm run lint-fix`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6840c5308c588333ae1d47248ea97043