### PR TITLE
Indicate loading when changing filters

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -6,6 +6,7 @@ import ItemPicker, {
     ItemPickerFallback,
 } from "^/components/ItemPicker/ItemPicker";
 import Rankings, { RankingsFallback } from "^/components/Rankings";
+import RankingsBoundary from "^/components/RankingsBoundary";
 import TalentPicker from "^/components/TalentPicker";
 import { TalentPickerFallback } from "^/components/TalentPicker/TalentPicker";
 import ZonePickers from "^/components/ZonePickers";
@@ -151,9 +152,9 @@ export default async function Home(props: HomeProps) {
             >
                 <ItemPicker className="mb-4 flex items-start space-x-2 px-8" />
             </Suspense>
-            <Suspense fallback={<RankingsFallback className="px-8" />}>
+            <RankingsBoundary fallback={<RankingsFallback className="px-8" />}>
                 <Rankings className="px-8" rawParams={props.searchParams} />
-            </Suspense>
+            </RankingsBoundary>
             <Suspense>
                 <CanonicalFooter
                     rawParams={props.searchParams}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,10 +20,14 @@ select {
  * static dim reads as inactive without the distraction of motion or a
  * misleading "forbidden" cursor. */
 select:disabled {
-    @apply opacity-50;
+    @apply opacity-60;
 }
 
 input {
     @apply p-1;
     @apply rounded-md;
+}
+
+input:disabled {
+    @apply opacity-60;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,24 @@ select {
     @apply rounded-md;
 }
 
+/* While a filter navigation is in flight every dropdown is disabled. Keep it
+ * clearly dimmed the whole time and gently pulse it, so it reads as both
+ * inactive and loading rather than the barely-visible browser default. */
+@keyframes filter-loading {
+    0%,
+    100% {
+        opacity: 0.55;
+    }
+    50% {
+        opacity: 0.3;
+    }
+}
+
+select:disabled {
+    @apply cursor-not-allowed;
+    animation: filter-loading 1.2s ease-in-out infinite;
+}
+
 input {
     @apply p-1;
     @apply rounded-md;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,22 +16,11 @@ select {
     @apply rounded-md;
 }
 
-/* While a filter navigation is in flight every dropdown is disabled. Keep it
- * clearly dimmed the whole time and gently pulse it, so it reads as both
- * inactive and loading rather than the barely-visible browser default. */
-@keyframes filter-loading {
-    0%,
-    100% {
-        opacity: 0.55;
-    }
-    50% {
-        opacity: 0.3;
-    }
-}
-
+/* While a filter navigation is in flight the dropdowns are disabled. A plain,
+ * static dim reads as inactive without the distraction of motion or a
+ * misleading "forbidden" cursor. */
 select:disabled {
-    @apply cursor-not-allowed;
-    animation: filter-loading 1.2s ease-in-out infinite;
+    @apply opacity-50;
 }
 
 input {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { GithubIcon } from "lucide-react";
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
+import { NavigationTransitionProvider } from "^/lib/NavigationTransition";
 import "./globals.css";
 
 export const viewport: Viewport = {
@@ -58,7 +59,9 @@ export default async function RootLayout({
                         <GithubIcon />
                     </a>
                 </header>
-                {children}
+                <NavigationTransitionProvider>
+                    {children}
+                </NavigationTransitionProvider>
                 <Analytics />
             </body>
         </html>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ export default function Button({
             type="button"
             className={twMerge(
                 "rounded-md bg-zinc-700 p-2 hover:bg-zinc-600",
-                "disabled:opacity-50",
+                "disabled:opacity-60",
                 className,
             )}
             {...props}

--- a/src/components/DropdownFilter.tsx
+++ b/src/components/DropdownFilter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ReactEventHandler, useState } from "react";
+import { useNavigationTransition } from "^/lib/NavigationTransition";
 
 interface Option {
     label: string;
@@ -21,6 +22,11 @@ export default function DropdownFilter({
     setSelected,
 }: DropdownFilterProps) {
     const [localState, setLocalState] = useState(selected);
+    // While any filter navigation is in flight, lock every dropdown. This both
+    // signals that the page is loading and avoids a race: a second change would
+    // build its URL from the not-yet-committed search params and clobber the
+    // first change.
+    const { isPending } = useNavigationTransition();
 
     const onChange: ReactEventHandler<HTMLSelectElement> = (e) => {
         const val = e.target as HTMLSelectElement;
@@ -31,7 +37,13 @@ export default function DropdownFilter({
     };
 
     return (
-        <select onChange={onChange} value={localState} title={tooltip}>
+        <select
+            onChange={onChange}
+            value={localState}
+            title={tooltip}
+            disabled={isPending}
+            aria-busy={isPending}
+        >
             {options.map(({ value, label }) => (
                 <option key={value} value={value}>
                     {label}

--- a/src/components/ItemPicker/ItemFilter.tsx
+++ b/src/components/ItemPicker/ItemFilter.tsx
@@ -17,6 +17,7 @@ export interface ItemFilterProps extends ComponentProps<"div"> {
         apply?: boolean,
     ) => void;
     autofocus?: boolean;
+    disabled?: boolean;
 }
 
 export default function ItemFilter({
@@ -24,6 +25,7 @@ export default function ItemFilter({
     itemFilterChange,
     autofocus,
     className,
+    disabled,
     ...props
 }: ItemFilterProps) {
     return (
@@ -36,8 +38,9 @@ export default function ItemFilter({
         >
             <button
                 type="button"
-                className="absolute right-1 top-1"
+                className="absolute right-1 top-1 disabled:opacity-60"
                 onClick={() => itemFilterChange(null, true)}
+                disabled={disabled}
             >
                 ✖
             </button>
@@ -45,6 +48,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 autoFocus={autofocus}
                 value={itemFilter.name}
                 onChange={(e) =>
@@ -61,6 +65,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 value={itemFilter.id}
                 onChange={(e) =>
                     itemFilterChange(
@@ -76,6 +81,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 value={itemFilter.permanentEnchant}
                 onChange={(e) =>
                     itemFilterChange(
@@ -91,6 +97,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 value={itemFilter.temporaryEnchant}
                 onChange={(e) =>
                     itemFilterChange(
@@ -106,6 +113,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 value={itemFilter.bonusId}
                 onChange={(e) =>
                     itemFilterChange(
@@ -121,6 +129,7 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border"
+                disabled={disabled}
                 value={itemFilter.gemId}
                 onChange={(e) =>
                     itemFilterChange(

--- a/src/components/ItemPicker/ItemPicker.tsx
+++ b/src/components/ItemPicker/ItemPicker.tsx
@@ -10,7 +10,7 @@ import ItemFilter, { type ItemFilterConfig } from "./ItemFilter";
 export interface ItemPickerProps extends ComponentProps<"div"> {}
 
 export default function ItemPicker({ className, ...props }: ItemPickerProps) {
-    const { setParams, itemFilters } = useParsedParams();
+    const { setParams, itemFilters, isPending } = useParsedParams();
     const [localFilters, setLocalFilters] =
         useState<ItemFilterConfig[]>(itemFilters);
     const [autofocus, setAutofocus] = useState(false);
@@ -63,10 +63,13 @@ export default function ItemPicker({ className, ...props }: ItemPickerProps) {
                         }
                     }}
                     autofocus={autofocus}
+                    disabled={isPending}
                 />
             ))}
             <div className="flex flex-col gap-2">
-                <Button onClick={onClick}>Find Item</Button>
+                <Button disabled={isPending} onClick={onClick}>
+                    Find Item
+                </Button>
                 {!arrayEquals(
                     itemFilters,
                     localFilters,
@@ -78,7 +81,10 @@ export default function ItemPicker({ className, ...props }: ItemPickerProps) {
                         a.bonusId === b.bonusId &&
                         a.gemId === b.gemId,
                 ) && (
-                    <Button onClick={() => updateUrl(localFilters)}>
+                    <Button
+                        disabled={isPending}
+                        onClick={() => updateUrl(localFilters)}
+                    >
                         Apply
                     </Button>
                 )}

--- a/src/components/RankingsBoundary.tsx
+++ b/src/components/RankingsBoundary.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { type ReactNode, Suspense } from "react";
+import { useNavigationTransition } from "^/lib/NavigationTransition";
+
+export interface RankingsBoundaryProps {
+    /** The (server-rendered) `<Rankings>` element. */
+    children: ReactNode;
+    /** The loading placeholder, e.g. `<RankingsFallback />`. */
+    fallback: ReactNode;
+}
+
+/**
+ * Wraps the rankings results so they show the same loading indicator on a
+ * filter change as they do on the initial load.
+ *
+ * On the first render the `<Suspense>` boundary handles the streaming server
+ * render. On a subsequent filter change the App Router keeps the previous
+ * (stale) results on screen until the new server components commit, without
+ * ever re-triggering the Suspense fallback. To bridge that gap we swap in the
+ * fallback while the navigation transition is pending, so the results area
+ * looks identical to the initial load until the fresh data arrives.
+ */
+export default function RankingsBoundary({
+    children,
+    fallback,
+}: RankingsBoundaryProps) {
+    const { isPending } = useNavigationTransition();
+
+    return (
+        <Suspense fallback={fallback}>
+            {isPending ? fallback : children}
+        </Suspense>
+    );
+}

--- a/src/components/TalentPicker/TalentFilter.tsx
+++ b/src/components/TalentPicker/TalentFilter.tsx
@@ -15,6 +15,7 @@ export interface TalentFilterProps extends ComponentProps<"div"> {
     filter: TalentFilterConfig;
     filterChange: (filter: TalentFilterConfig | null, apply?: boolean) => void;
     autofocus?: boolean;
+    disabled?: boolean;
 }
 
 export default function TalentFilter({
@@ -26,6 +27,7 @@ export default function TalentFilter({
     talents,
     className,
     autoFocus,
+    disabled,
     ...props
 }: TalentFilterProps) {
     const filterItems = useCallback(
@@ -107,13 +109,18 @@ export default function TalentFilter({
         >
             <button
                 type="button"
-                className="absolute right-1 top-1"
+                className="absolute right-1 top-1 disabled:opacity-60"
                 onClick={() => filterChange(null, true)}
+                disabled={disabled}
             >
                 ✖
             </button>
             Talent Name 🔎{" "}
-            <input type="text" list="talentlist" {...getInputProps()} />
+            <input
+                type="text"
+                list="talentlist"
+                {...getInputProps({ disabled })}
+            />
             <div className="relative">
                 <ul
                     className={twMerge(
@@ -144,6 +151,7 @@ export default function TalentFilter({
             <input
                 type="text"
                 value={filter.talentId}
+                disabled={disabled}
                 onChange={(e) =>
                     filterChange({
                         name: filter.name,

--- a/src/components/TalentPicker/TalentPicker.client.tsx
+++ b/src/components/TalentPicker/TalentPicker.client.tsx
@@ -14,7 +14,7 @@ export interface TalentPickerClientProps {
 export default function TalentPickerClient({
     talents,
 }: TalentPickerClientProps) {
-    const { talents: paramFilters, setParams } = useParsedParams();
+    const { talents: paramFilters, setParams, isPending } = useParsedParams();
     const [filters, setFilters] = useState<TalentFilterConfig[]>(paramFilters);
     const [autofocus, setAutofocus] = useState(false);
 
@@ -48,10 +48,12 @@ export default function TalentPickerClient({
                         }
                     }}
                     autoFocus={autofocus}
+                    disabled={isPending}
                 />
             ))}
             <div className="flex flex-col gap-2">
                 <Button
+                    disabled={isPending}
                     onClick={() =>
                         setFilters((curr) => [
                             ...curr,
@@ -68,7 +70,14 @@ export default function TalentPickerClient({
                     paramFilters,
                     filters,
                     (a, b) => a.name === b.name && a.talentId === b.talentId,
-                ) && <Button onClick={() => updateUrl(filters)}>Apply</Button>}
+                ) && (
+                    <Button
+                        disabled={isPending}
+                        onClick={() => updateUrl(filters)}
+                    >
+                        Apply
+                    </Button>
+                )}
             </div>
         </>
     );

--- a/src/lib/NavigationTransition.tsx
+++ b/src/lib/NavigationTransition.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+    createContext,
+    type ReactNode,
+    type TransitionStartFunction,
+    useContext,
+    useTransition,
+} from "react";
+
+interface NavigationTransition {
+    /**
+     * Whether a navigation started via {@link startTransition} is currently
+     * in flight (the new server components have not committed yet).
+     */
+    isPending: boolean;
+    /**
+     * Wraps the navigation so that {@link isPending} stays `true` for the whole
+     * round-trip, from the moment the user acts until the new page commits.
+     */
+    startTransition: TransitionStartFunction;
+}
+
+const NavigationTransitionContext = createContext<NavigationTransition | null>(
+    null,
+);
+
+/**
+ * Shares a single {@link useTransition} across every filter, so that a
+ * navigation started by one control (e.g. a dropdown) exposes its pending
+ * state to all of them. This lets us disable every filter while data loads and
+ * lets the results area show a loading indicator, instead of leaving the page
+ * looking frozen while the new server components stream in.
+ */
+export function NavigationTransitionProvider({
+    children,
+}: {
+    children: ReactNode;
+}) {
+    const [isPending, startTransition] = useTransition();
+
+    return (
+        <NavigationTransitionContext.Provider
+            value={{ isPending, startTransition }}
+        >
+            {children}
+        </NavigationTransitionContext.Provider>
+    );
+}
+
+export function useNavigationTransition() {
+    const context = useContext(NavigationTransitionContext);
+
+    if (context == null) {
+        throw new Error(
+            "useNavigationTransition must be used within a NavigationTransitionProvider",
+        );
+    }
+
+    return context;
+}

--- a/src/lib/useParsedParams.ts
+++ b/src/lib/useParsedParams.ts
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
+import { useNavigationTransition } from "./NavigationTransition";
 import { type ParsedParams, parseParams, toParams } from "./Params";
 import { removeNonCanonicalParams } from "./seo-utils";
 import { createUrl } from "./utils";
@@ -9,6 +10,7 @@ import { createUrl } from "./utils";
 export function useParsedParams() {
     const router = useRouter();
     const searchParams = useSearchParams();
+    const { isPending, startTransition } = useNavigationTransition();
 
     const buildUrl = useCallback(
         (params: Partial<ParsedParams>, { canonical = false } = {}) => {
@@ -33,14 +35,21 @@ export function useParsedParams() {
 
     const setParams = useCallback(
         (params: Partial<ParsedParams>) => {
-            router.replace(buildUrl(params));
+            // Wrap the navigation in the shared transition so `isPending` stays
+            // `true` until the new server components have streamed in and
+            // committed. Consumers use it to indicate loading and to lock the
+            // filters while data is fetched.
+            startTransition(() => {
+                router.replace(buildUrl(params));
+            });
         },
-        [buildUrl, router],
+        [buildUrl, router, startTransition],
     );
 
     return {
         ...parseParams(searchParams),
         buildUrl,
         setParams,
+        isPending,
     };
 }


### PR DESCRIPTION
## Problem

Changing a dropdown filter navigates via `router.replace`, which re-renders the server components from the new search params. With the App Router, a search-param-only navigation keeps the previous UI on screen until the new render commits and does **not** re-trigger the `Suspense` fallback (see [vercel/next.js#53543](https://github.com/vercel/next.js/issues/53543)). The result: after picking a new filter value, the page looked frozen with no indication that anything was loading.

## Approach

Because `router.push`/`replace` navigations run as React transitions, wrapping the call in `useTransition` gives an `isPending` flag that stays `true` for the whole RSC round-trip — the recommended pattern for programmatic-navigation loading state, and it works with `cacheComponents`. A single shared transition lets one control's navigation surface its pending state to all of them.

## Changes

- **`src/lib/NavigationTransition.tsx`** (new) — `NavigationTransitionProvider` holding one shared `useTransition`, exposing `{ isPending, startTransition }` via context.
- **`src/app/layout.tsx`** — wraps `{children}` in the provider (server children stay server-rendered).
- **`src/lib/useParsedParams.ts`** — `setParams` now runs `router.replace` inside the shared `startTransition`, and returns `isPending`.
- **`src/components/RankingsBoundary.tsx`** (new) + **`page.tsx`** — while a navigation is pending, the results area shows the existing `RankingsFallback` instead of stale results, so a filter change shows the **same loading indicator as the initial load**. Scoped to the rankings only — the picker rows use cached, search-param-independent data, so they aren't blanked.
- **`src/components/DropdownFilter.tsx`** — every dropdown is `disabled` (+ `aria-busy`) while pending. Besides signalling the load, this prevents a race where a second change would build its URL from the not-yet-committed search params and clobber the first change.

## Testing

- `tsc --noEmit`: clean (the one pre-existing error in `Params.test.ts` is unrelated and present on `main`).
- `eslint` on all changed files: clean.
- `next build`: compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DamZGJF3HjCkiLRcu6At5Z)_