### PR TITLE
Update to Midnight expansion (The Voidspire)

### DIFF
--- a/src/lib/Params.ts
+++ b/src/lib/Params.ts
@@ -81,12 +81,12 @@ const paramTypes = Object.freeze({
     zone: {
         name: "zone",
         type: "number",
-        default: 44, // Manaforge Omega
+        default: 46, // The Voidspire
     },
     encounter: {
         name: "encounter",
         type: "number",
-        default: 3129, // Plexus Sentinel
+        default: 3176, // Imperator Averzian
     },
     difficulty: {
         name: "difficulty",

--- a/src/lib/__tests__/Params.test.ts
+++ b/src/lib/__tests__/Params.test.ts
@@ -5,8 +5,8 @@ describe("Params utils", () => {
         const parsed = parseParams(new URLSearchParams());
         expect(parsed).toEqual({
             region: null,
-            zone: 44,
-            encounter: 3129,
+            zone: 46,
+            encounter: 3176,
             difficulty: 5,
             partition: null,
             metric: "dps",
@@ -58,7 +58,7 @@ describe("Params utils", () => {
         const sp = toParams(defaultParams, { pruneDefaults: false });
 
         expect(sp.toString()).toBe(
-            "zone=44&encounter=3129&difficulty=5&metric=dps&pages=1",
+            "zone=46&encounter=3176&difficulty=5&metric=dps&pages=1",
         );
     });
 

--- a/src/lib/wcl/zones.ts
+++ b/src/lib/wcl/zones.ts
@@ -36,7 +36,7 @@ const Zone = /* GraphQL */ `
 const query = /* GraphQL */ `
     query getZones {
         worldData {
-            zones(expansion_id: 6) {
+            zones(expansion_id: 7) {
                 ...Zone
             }
         }


### PR DESCRIPTION
Bumps the WoW expansion the tool targets from **The War Within** to **Midnight**. The raid/zone list is fetched dynamically from Warcraft Logs filtered by expansion, so the change is a config bump plus updating the hardcoded defaults to the current Midnight raid tier (**The Voidspire**).

## Changes

- **`src/lib/wcl/zones.ts`** — fetch zones for `expansion_id: 7` (Midnight) instead of `6` (The War Within).
- **`src/lib/Params.ts`** — update default zone/encounter to the current tier:
  - zone `44` (Manaforge Omega) → `46` (The Voidspire)
  - encounter `3129` (Plexus Sentinel) → `3176` (Imperator Averzian)
- **`src/lib/__tests__/Params.test.ts`** — update expected defaults to match.

Difficulty stays Mythic (`5`). Zone/encounter dropdowns are still populated live from WCL, so no other data is hardcoded.

## Verification

Values confirmed against Warcraft Logs data: WCL `expansion_id` `7` = Midnight (War Within = `6`), zone `46` = The Voidspire, first boss Imperator Averzian = `3176`, Mythic = difficulty `5`.

- Tests: 10/10 pass (`jest`)
- Lint: clean (`eslint`) on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FWrRWTA6ykmSmC7xdzmzq)_