### PR TITLE
Auto-select the current expansion and raid tier

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -14,6 +14,7 @@ import { parseParams, type RawParams } from "^/lib/Params";
 import { generateCanonicalUrl } from "^/lib/seo-utils";
 import { isNotNull } from "^/lib/utils";
 import { getClasses } from "^/lib/wcl/classes";
+import { getDefaultSelection } from "^/lib/wcl/currentTier";
 import getRankings from "^/lib/wcl/rankings";
 import { getZones } from "^/lib/wcl/zones";
 
@@ -28,7 +29,7 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
         const {
             classId,
             specId,
-            encounter,
+            encounter: encounterParam,
             difficulty,
             metric,
             pages,
@@ -46,6 +47,10 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
             },
         };
 
+        const encounters = await getZones();
+        const defaults = getDefaultSelection(encounters);
+        const encounter = encounterParam ?? defaults.encounter;
+
         if (!encounter) {
             return {
                 ...metadata,
@@ -53,11 +58,10 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
             };
         }
 
-        const [encounters, classes, { filteredCount }] = await Promise.all([
-            getZones(),
+        const [classes, { filteredCount }] = await Promise.all([
             getClasses(),
             getRankings({
-                difficulty,
+                difficulty: difficulty ?? defaults.difficulty,
                 encounter,
                 klass: classId,
                 pages,

--- a/src/components/Rankings.tsx
+++ b/src/components/Rankings.tsx
@@ -5,7 +5,9 @@ import { isNotFoundError } from "^/lib/Errors";
 import { type ParsedParams, parseParams, type RawParams } from "^/lib/Params";
 import { buildWclUrl } from "^/lib/utils";
 import { getClasses } from "^/lib/wcl/classes";
+import { getDefaultSelection } from "^/lib/wcl/currentTier";
 import getRankings, { type NullCharacterRankings } from "^/lib/wcl/rankings";
+import { getZones } from "^/lib/wcl/zones";
 import PageLinks from "./PageLinks";
 
 export interface RankingsProps extends ComponentProps<"div"> {
@@ -20,18 +22,31 @@ export default async function Rankings({ rawParams, ...props }: RankingsProps) {
     try {
         parsedParams = parseParams(searchParams);
 
-        characterRankings = await getRankings({
-            difficulty: parsedParams.difficulty,
-            encounter: parsedParams.encounter,
-            klass: parsedParams.classId,
-            pages: parsedParams.pages,
-            partition: parsedParams.partition,
-            metric: parsedParams.metric,
-            region: parsedParams.region,
-            spec: parsedParams.specId,
-            talents: parsedParams.talents,
-            itemFilters: parsedParams.itemFilters,
-        });
+        const defaults = getDefaultSelection(await getZones());
+        const encounter = parsedParams.encounter ?? defaults.encounter;
+        const difficulty = parsedParams.difficulty ?? defaults.difficulty;
+
+        characterRankings =
+            encounter == null
+                ? {
+                      count: 0,
+                      filteredCount: 0,
+                      hasMorePages: false,
+                      pages: [],
+                      rankings: [],
+                  }
+                : await getRankings({
+                      difficulty,
+                      encounter,
+                      klass: parsedParams.classId,
+                      pages: parsedParams.pages,
+                      partition: parsedParams.partition,
+                      metric: parsedParams.metric,
+                      region: parsedParams.region,
+                      spec: parsedParams.specId,
+                      talents: parsedParams.talents,
+                      itemFilters: parsedParams.itemFilters,
+                  });
     } catch (error: unknown) {
         if (isNotFoundError(error)) {
             notFound();

--- a/src/components/ZonePickers/DifficultyPicker.tsx
+++ b/src/components/ZonePickers/DifficultyPicker.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
+import { getDefaultZone } from "^/lib/wcl/currentTier";
 import { type Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
 
@@ -13,14 +14,18 @@ export interface DifficultyPickerProps {
 export default function DifficultyPicker({ zones }: DifficultyPickerProps) {
     const { zone, difficulty, setParams, buildUrl } = useParsedParams();
 
-    if (zone == null) {
+    const selectedZone = zone ?? getDefaultZone(zones)?.id;
+
+    if (selectedZone == null) {
         return null;
     }
 
-    const difficulties = zones.find((z) => z.id === Number(zone))?.difficulties;
+    const difficulties = zones.find(
+        (z) => z.id === Number(selectedZone),
+    )?.difficulties;
     if (difficulties == null) {
         throw new MalformedUrlParameterError(
-            `Zone ${zone} has no difficulties`,
+            `Zone ${selectedZone} has no difficulties`,
         );
     }
 

--- a/src/components/ZonePickers/EncounterPicker.tsx
+++ b/src/components/ZonePickers/EncounterPicker.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
+import { getDefaultZone } from "^/lib/wcl/currentTier";
 import type { Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
 
@@ -13,14 +14,22 @@ export interface EncounterPickerProps {
 export default function EncounterPicker({ zones }: EncounterPickerProps) {
     const { zone, encounter, setParams, buildUrl } = useParsedParams();
 
-    if (zone == null) {
+    const selectedZone = zone ?? getDefaultZone(zones)?.id;
+
+    if (selectedZone == null) {
         return null;
     }
-    const encounters = zones.find((z) => z.id === Number(zone))?.encounters;
+    const encounters = zones.find(
+        (z) => z.id === Number(selectedZone),
+    )?.encounters;
 
     if (encounters == null) {
-        throw new MalformedUrlParameterError(`Zone ${zone} has no encounters`);
+        throw new MalformedUrlParameterError(
+            `Zone ${selectedZone} has no encounters`,
+        );
     }
+
+    const selectedEncounter = encounter ?? encounters[0]?.id;
 
     return (
         <>
@@ -30,8 +39,10 @@ export default function EncounterPicker({ zones }: EncounterPickerProps) {
                     label: e.name,
                     value: String(e.id),
                 }))}
-                selected={encounter ? String(encounter) : ""}
-                key={encounter}
+                selected={
+                    selectedEncounter != null ? String(selectedEncounter) : ""
+                }
+                key={selectedEncounter}
                 setSelected={(encounter) =>
                     setParams({ encounter: Number(encounter) })
                 }

--- a/src/components/ZonePickers/PartitionPicker.tsx
+++ b/src/components/ZonePickers/PartitionPicker.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
+import { getDefaultZone } from "^/lib/wcl/currentTier";
 import type { Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
 
@@ -13,13 +14,19 @@ export interface PartitionPickerProps {
 export default function PartitionPicker({ zones }: PartitionPickerProps) {
     const { zone, partition, setParams, buildUrl } = useParsedParams();
 
-    if (zone == null) {
+    const selectedZone = zone ?? getDefaultZone(zones)?.id;
+
+    if (selectedZone == null) {
         return null;
     }
 
-    const partitions = zones.find((z) => z.id === Number(zone))?.partitions;
+    const partitions = zones.find(
+        (z) => z.id === Number(selectedZone),
+    )?.partitions;
     if (partitions == null) {
-        throw new MalformedUrlParameterError(`Zone ${zone} has no partitions`);
+        throw new MalformedUrlParameterError(
+            `Zone ${selectedZone} has no partitions`,
+        );
     }
 
     if (partitions.length === 1) {

--- a/src/components/ZonePickers/ZonePicker.tsx
+++ b/src/components/ZonePickers/ZonePicker.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useParsedParams } from "^/lib/useParsedParams";
+import { getDefaultZone } from "^/lib/wcl/currentTier";
 import type { Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
 
@@ -12,6 +13,8 @@ export interface ZonePickerProps {
 export default function ZonePicker({ zones }: ZonePickerProps) {
     const { zone, setParams, buildUrl } = useParsedParams();
 
+    const selectedZone = zone ?? getDefaultZone(zones)?.id;
+
     return (
         <>
             <DropdownFilter
@@ -20,8 +23,8 @@ export default function ZonePicker({ zones }: ZonePickerProps) {
                     label: z.name,
                     value: String(z.id),
                 }))}
-                selected={zone ? String(zone) : ""}
-                key={zone}
+                selected={selectedZone != null ? String(selectedZone) : ""}
+                key={selectedZone}
                 setSelected={(zone) => {
                     const { encounters, difficulties } =
                         zones.find((z) => z.id === Number(zone)) ?? {};

--- a/src/lib/Params.ts
+++ b/src/lib/Params.ts
@@ -81,17 +81,19 @@ const paramTypes = Object.freeze({
     zone: {
         name: "zone",
         type: "number",
-        default: 44, // Manaforge Omega
+        // Resolved to the current raid tier from the WCL zone list when absent.
+        default: null,
     },
     encounter: {
         name: "encounter",
         type: "number",
-        default: 3129, // Plexus Sentinel
+        // Resolved to the first encounter of the default zone when absent.
+        default: null,
     },
     difficulty: {
         name: "difficulty",
         type: "number",
-        default: 5, // Mythic
+        default: 5, // Mythic (constant across expansions)
     },
     partition: {
         name: "partition",

--- a/src/lib/__tests__/Params.test.ts
+++ b/src/lib/__tests__/Params.test.ts
@@ -5,8 +5,8 @@ describe("Params utils", () => {
         const parsed = parseParams(new URLSearchParams());
         expect(parsed).toEqual({
             region: null,
-            zone: 44,
-            encounter: 3129,
+            zone: null,
+            encounter: null,
             difficulty: 5,
             partition: null,
             metric: "dps",
@@ -57,9 +57,7 @@ describe("Params utils", () => {
         const defaultParams = parseParams(new URLSearchParams());
         const sp = toParams(defaultParams, { pruneDefaults: false });
 
-        expect(sp.toString()).toBe(
-            "zone=44&encounter=3129&difficulty=5&metric=dps&pages=1",
-        );
+        expect(sp.toString()).toBe("difficulty=5&metric=dps&pages=1");
     });
 
     test("toParams prunes empty arrays regardless of pruneDefaults", () => {

--- a/src/lib/wcl/__tests__/currentTier.test.ts
+++ b/src/lib/wcl/__tests__/currentTier.test.ts
@@ -1,0 +1,92 @@
+import { getDefaultSelection, getDefaultZone } from "../currentTier";
+import type { Zone } from "../zones";
+
+function makeZone(overrides: Partial<Zone> & Pick<Zone, "id">): Zone {
+    return {
+        name: `Zone ${overrides.id}`,
+        partitions: [{ id: 1, name: "Partition 1" }],
+        encounters: [{ id: overrides.id * 10, name: "Boss 1" }],
+        difficulties: [
+            { id: 3, name: "Normal" },
+            { id: 4, name: "Heroic" },
+            { id: 5, name: "Mythic" },
+        ],
+        ...overrides,
+    };
+}
+
+// A Mythic+ / dungeon zone: no Mythic raid difficulty (id 5).
+const mythicPlusZone: Zone = {
+    id: 99,
+    name: "Mythic+ Season",
+    partitions: [{ id: 1, name: "Partition 1" }],
+    encounters: [{ id: 990, name: "Dungeon 1" }],
+    difficulties: [{ id: 10, name: "Mythic+" }],
+};
+
+describe("getDefaultZone", () => {
+    test("returns the highest-id raid (has Mythic difficulty)", () => {
+        const zones = [
+            makeZone({ id: 40 }),
+            makeZone({ id: 46 }),
+            makeZone({ id: 42 }),
+        ];
+
+        expect(getDefaultZone(zones)?.id).toBe(46);
+    });
+
+    test("ignores zones without a Mythic difficulty (e.g. Mythic+)", () => {
+        // The M+ zone has the highest id but must not win.
+        const zones = [makeZone({ id: 46 }), mythicPlusZone];
+
+        expect(getDefaultZone(zones)?.id).toBe(46);
+    });
+
+    test("falls back to newest zone with encounters when no raids exist", () => {
+        const zones = [
+            mythicPlusZone,
+            {
+                ...mythicPlusZone,
+                id: 100,
+                encounters: [{ id: 1000, name: "D" }],
+            },
+        ];
+
+        expect(getDefaultZone(zones)?.id).toBe(100);
+    });
+
+    test("returns undefined for an empty zone list", () => {
+        expect(getDefaultZone([])).toBeUndefined();
+    });
+});
+
+describe("getDefaultSelection", () => {
+    test("resolves zone, first encounter and Mythic difficulty", () => {
+        const zones = [makeZone({ id: 42 }), makeZone({ id: 46 })];
+
+        expect(getDefaultSelection(zones)).toEqual({
+            zone: 46,
+            encounter: 460,
+            difficulty: 5,
+        });
+    });
+
+    test("uses the first difficulty when the zone has no Mythic", () => {
+        const zones = [
+            {
+                ...mythicPlusZone,
+                encounters: [{ id: 990, name: "Dungeon 1" }],
+            },
+        ];
+
+        expect(getDefaultSelection(zones)).toEqual({
+            zone: 99,
+            encounter: 990,
+            difficulty: 10,
+        });
+    });
+
+    test("returns an empty object when there are no zones", () => {
+        expect(getDefaultSelection([])).toEqual({});
+    });
+});

--- a/src/lib/wcl/currentTier.ts
+++ b/src/lib/wcl/currentTier.ts
@@ -1,0 +1,60 @@
+import type { Zone } from "./zones";
+
+/**
+ * Pure helpers for resolving the "current" raid tier from a Warcraft Logs zone
+ * list. Kept free of server-only imports so both server components and client
+ * pickers can use them.
+ */
+
+/** Warcraft Logs difficulty id for Mythic raids. Constant across expansions. */
+export const MYTHIC_DIFFICULTY_ID = 5;
+
+/**
+ * The raid tier to select by default: the most recent raid of the current
+ * expansion. Raids are identified by offering a Mythic difficulty, which
+ * excludes Mythic+/PvP zones; among those the most recent has the highest id.
+ * Falls back to the newest zone that has encounters when no raid is found
+ * (e.g. a fresh expansion before its first raid opens).
+ */
+export function getDefaultZone(zones: Zone[]): Zone | undefined {
+    const raids = zones.filter((zone) =>
+        zone.difficulties.some(({ id }) => id === MYTHIC_DIFFICULTY_ID),
+    );
+
+    const candidates =
+        raids.length > 0
+            ? raids
+            : zones.filter((zone) => zone.encounters.length > 0);
+
+    return candidates.reduce<Zone | undefined>(
+        (latest, zone) =>
+            latest == null || zone.id > latest.id ? zone : latest,
+        undefined,
+    );
+}
+
+/**
+ * Resolves the default zone/encounter/difficulty from the given zones, used
+ * when the corresponding URL params are absent. Empty when there are no zones.
+ */
+export function getDefaultSelection(zones: Zone[]): {
+    zone?: number;
+    encounter?: number;
+    difficulty?: number;
+} {
+    const zone = getDefaultZone(zones);
+
+    if (zone == null) {
+        return {};
+    }
+
+    return {
+        zone: zone.id,
+        encounter: zone.encounters[0]?.id,
+        difficulty: zone.difficulties.some(
+            ({ id }) => id === MYTHIC_DIFFICULTY_ID,
+        )
+            ? MYTHIC_DIFFICULTY_ID
+            : zone.difficulties[0]?.id,
+    };
+}

--- a/src/lib/wcl/zones.ts
+++ b/src/lib/wcl/zones.ts
@@ -33,10 +33,21 @@ const Zone = /* GraphQL */ `
     }
 `;
 
-const query = /* GraphQL */ `
-    query getZones {
+const expansionsQuery = /* GraphQL */ `
+    query getExpansions {
         worldData {
-            zones(expansion_id: 6) {
+            expansions {
+                id
+                name
+            }
+        }
+    }
+`;
+
+const zonesQuery = /* GraphQL */ `
+    query getZones($expansionId: Int!) {
+        worldData {
+            zones(expansion_id: $expansionId) {
                 ...Zone
             }
         }
@@ -44,21 +55,50 @@ const query = /* GraphQL */ `
     ${Zone}
 `;
 
+async function getExpansions() {
+    "use cache: remote";
+
+    cacheLife("expansion");
+
+    const {
+        worldData: { expansions },
+    } = await wclFetch<{
+        worldData: {
+            expansions: { id: number; name: string }[];
+        };
+    }>(expansionsQuery);
+
+    // Newest expansion first.
+    return [...expansions].sort((a, b) => b.id - a.id);
+}
+
 export async function getZones() {
     "use cache: remote";
 
     cacheLife("patch");
 
-    const {
-        worldData: { zones },
-    } = await wclFetch<{
-        worldData: {
-            zones: Zone[];
-        };
-    }>(query);
+    // Walk expansions newest-first and return the zones of the most recent one
+    // that actually has any. This keeps the tool pointed at current content
+    // without hardcoding an expansion id, and gracefully skips a next
+    // expansion that Warcraft Logs may list before it has any logged zones.
+    const expansions = await getExpansions();
 
-    return zones.map(({ partitions, ...zone }) => ({
-        ...zone,
-        partitions: partitions.reverse(),
-    }));
+    for (const { id } of expansions) {
+        const {
+            worldData: { zones },
+        } = await wclFetch<{
+            worldData: {
+                zones: Zone[];
+            };
+        }>(zonesQuery, { expansionId: id });
+
+        if (zones.length > 0) {
+            return zones.map(({ partitions, ...zone }) => ({
+                ...zone,
+                partitions: partitions.reverse(),
+            }));
+        }
+    }
+
+    return [];
 }


### PR DESCRIPTION
Follow-up to #204. Removes the need to hand-edit the expansion id and the default raid/encounter every tier by deriving them from the Warcraft Logs API.

## Motivation

Each new raid tier required updating `expansion_id` (in `zones.ts`) plus the default `zone` and `encounter` (in `Params.ts`). Those values are just "the latest expansion" and "the newest raid + its first boss," which the API already knows.

## Changes

- **`zones.ts`** — query `worldData.expansions` and fetch zones for the most recent expansion that actually has any (gracefully skips a next expansion that WCL may list before it has logged zones), instead of a hardcoded `expansion_id`.
- **`currentTier.ts`** (new) — pure, server- and client-safe helpers that resolve the "current" tier from a zone list: the newest zone offering a **Mythic** difficulty (which excludes Mythic+/PvP zones), with a fallback to the newest zone that has encounters. Kept free of server-only imports so the client pickers can use it too.
- **`Params.ts`** — `zone`/`encounter` defaults become `null`; they're resolved to the current tier wherever a concrete value is needed. `difficulty` stays `5` (Mythic is constant across expansions).
- **`Rankings.tsx`** / **`page.tsx`** — resolve the default encounter/difficulty from the fetched zones before querying rankings / building metadata.
- **Zone / Encounter / Difficulty / Partition pickers** — fall back to the resolved default zone so a paramless visit still shows the current tier selected.

## Result

A bare visit to `/` always lands on the current raid with **no per-expansion code change**, and the homepage URL no longer bakes in tier-specific ids.

## How "current tier" is chosen

Newest zone (highest WCL zone id) within the latest expansion that offers a Mythic difficulty. This matches exactly what was hand-picked before and naturally excludes the Mythic+ dungeon zone.

## Verification

- Tests: full suite passes, including new `currentTier` unit tests (raid selection, M+ exclusion, fallback, empty list). `Params` default-related tests updated.
- Lint: clean.
- `next build` compiles and type-checks through to page generation (it only stops at prerender because this sandbox has no `WCL_CLIENT_ID` — same as `main`).

Note: I couldn't exercise this against the live WCL API from the build environment (no credentials there), so the tier-resolution logic is validated against the schema and unit tests rather than a live response — worth a quick sanity check in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FWrRWTA6ykmSmC7xdzmzq)_