### PR TITLE
Add CLAUDE.md with code-comment guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# Guidance for Claude Code
+
+## Code comments
+
+Don't write code comments by default. Convey meaning through names, types, and
+structure instead.
+
+If you think a comment is genuinely needed — a non-obvious constraint, an API
+quirk, or a deliberate workaround that a developer could not infer from the code
+itself — don't add it silently; surface it and let me decide.
+
+Inline comments are read by developers years from now who have no knowledge of
+the change that introduced them. Never write a comment that argues for a change,
+describes what you just did, or references review feedback or our discussion.
+That belongs in the pull request, not in the code.


### PR DESCRIPTION
Adds a repo-level `CLAUDE.md` so Claude Code sessions default to **not** writing code comments, and never use comments to argue for a change or replay review feedback.

A repo `CLAUDE.md` is part of the clone, so it applies to every session that opens this repo — local, web, and cloud — unlike a machine-local `~/.claude/CLAUDE.md`, which does not carry over to cloud sessions.

The rule: comments off by default; if one seems genuinely needed (a non-obvious constraint, API quirk, or deliberate workaround), surface it rather than adding it silently; and never write comments aimed at the current change or review conversation — inline comments are for future readers, not the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DamZGJF3HjCkiLRcu6At5Z)_