### PR TITLE
Stop invalid search parameters from reaching WarcraftLogs

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from "next";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import CanonicalFooter from "^/components/CanonicalFooter";
 import ClassPickers from "^/components/ClassPickers";
@@ -10,7 +11,7 @@ import RankingsBoundary from "^/components/RankingsBoundary";
 import TalentPicker from "^/components/TalentPicker";
 import { TalentPickerFallback } from "^/components/TalentPicker/TalentPicker";
 import ZonePickers from "^/components/ZonePickers";
-import { isNotFoundError } from "^/lib/Errors";
+import { isNotFoundError, MalformedUrlParameterError } from "^/lib/Errors";
 import { parseParams, type RawParams } from "^/lib/Params";
 import { generateCanonicalUrl, isIndexable } from "^/lib/seo-utils";
 import { isNotNull } from "^/lib/utils";
@@ -30,6 +31,7 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
         const {
             classId,
             specId,
+            zone,
             encounter,
             difficulty,
             metric,
@@ -61,8 +63,13 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
             };
         }
 
-        const [encounters, classes, { filteredCount }] = await Promise.all([
-            getZones(),
+        const zones = await getZones();
+
+        if (!zones.some((z) => z.id === zone)) {
+            throw new MalformedUrlParameterError(`Zone ${zone} not found`);
+        }
+
+        const [classes, { filteredCount }] = await Promise.all([
             getClasses(),
             getRankings({
                 difficulty,
@@ -90,7 +97,7 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
         const spec =
             specId != null ? klass?.specs.find((s) => s.id === specId) : null;
 
-        const encounterName = encounters
+        const encounterName = zones
             .find((z) => z.encounters.some((e) => e.id === encounter))
             ?.encounters.find((e) => e.id === encounter)?.name;
 
@@ -105,14 +112,16 @@ export async function generateMetadata(props: HomeProps): Promise<Metadata> {
             title: `${title} - ${filteredCount} results | Warcraftlogs Search`,
         };
     } catch (e: unknown) {
-        const notFoundError = isNotFoundError(e);
+        if (isNotFoundError(e)) {
+            notFound();
+        }
 
         return {
             robots: {
                 index: false,
                 follow: true,
             },
-            title: `${notFoundError ? "404 | Not found" : "500 | Error"} | Warcraftlogs Search`,
+            title: "500 | Error | Warcraftlogs Search",
         };
     }
 }

--- a/src/components/ZonePickers/DifficultyPicker.tsx
+++ b/src/components/ZonePickers/DifficultyPicker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
 import { type Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
@@ -19,9 +18,7 @@ export default function DifficultyPicker({ zones }: DifficultyPickerProps) {
 
     const difficulties = zones.find((z) => z.id === Number(zone))?.difficulties;
     if (difficulties == null) {
-        throw new MalformedUrlParameterError(
-            `Zone ${zone} has no difficulties`,
-        );
+        return null;
     }
 
     if (difficulties.length === 1) {

--- a/src/components/ZonePickers/EncounterPicker.tsx
+++ b/src/components/ZonePickers/EncounterPicker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
@@ -19,7 +18,7 @@ export default function EncounterPicker({ zones }: EncounterPickerProps) {
     const encounters = zones.find((z) => z.id === Number(zone))?.encounters;
 
     if (encounters == null) {
-        throw new MalformedUrlParameterError(`Zone ${zone} has no encounters`);
+        return null;
     }
 
     return (

--- a/src/components/ZonePickers/PartitionPicker.tsx
+++ b/src/components/ZonePickers/PartitionPicker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Zone } from "^/lib/wcl/zones";
 import DropdownFilter from "../DropdownFilter";
@@ -19,7 +18,7 @@ export default function PartitionPicker({ zones }: PartitionPickerProps) {
 
     const partitions = zones.find((z) => z.id === Number(zone))?.partitions;
     if (partitions == null) {
-        throw new MalformedUrlParameterError(`Zone ${zone} has no partitions`);
+        return null;
     }
 
     if (partitions.length === 1) {

--- a/src/lib/wcl/rankings.ts
+++ b/src/lib/wcl/rankings.ts
@@ -243,20 +243,19 @@ const getRankingsInternal = cache(async function getRankingsInternal(
     let klassName: string | undefined;
     let specName: string | undefined;
 
-    // if partition is not specified, try to determine it
-    if (partition == null) {
-        const zones = await getZones();
+    const zones = await getZones();
 
-        const zone = zones.find((z) =>
-            z.encounters.some((e) => e.id === encounter),
+    const zone = zones.find((z) =>
+        z.encounters.some((e) => e.id === encounter),
+    );
+
+    if (zone == null) {
+        throw new MalformedUrlParameterError(
+            `Zone with encounter ${encounter} not found`,
         );
+    }
 
-        if (zone == null) {
-            throw new MalformedUrlParameterError(
-                `Zone with encounter ${encounter} not found`,
-            );
-        }
-
+    if (partition == null) {
         // Internally set partition to be first value
         partition = zone.partitions[0].id;
     }


### PR DESCRIPTION
## Summary
- Supplying an explicit `partition` in the URL skipped the zone/encounter
  membership check entirely (src/lib/wcl/rankings.ts), so a bogus encounter
  reached the cached fetch and cost a WarcraftLogs call plus a cache write
  for a URL that could never return results. The membership check now always
  runs; only the partition-defaulting is conditional on `partition == null`.
- Also validates the zone in `generateMetadata` (src/app/(main)/page.tsx),
  which runs before the response begins. Previously the zone was only
  checked inside the client pickers (EncounterPicker, DifficultyPicker,
  PartitionPicker), which render after the response has already started —
  and the three disagreed: EncounterPicker/DifficultyPicker threw, surfacing
  the 500 view, while the identical condition in Rankings.tsx surfaced the
  404 view. All three pickers now render nothing (`return null`) instead of
  throwing, and the single up-front check in generateMetadata is what
  actually decides the outcome.

## IMPORTANT — this does NOT change the HTTP status code (still 200)
This was the known risk flagged going in, and it was tested, not assumed.
This repo has `cacheComponents: true` in next.config.ts. Verified against a
local production build (`pnpm build && pnpm start`, with the WCL API and
Raidbots fetch stubbed locally since no live credentials exist in that
sandbox — reverted before pushing, not part of this diff):
- `notFound()` called from `generateMetadata` DOES fire (the response body
  is the not-found view, with noindex) but the static shell has already
  committed a 200 by the time it runs. `curl -i` on an invalid `?zone=44`
  returns `200`, not `404`.
- Tried `export const dynamic = "force-dynamic"` to opt the route out of the
  static shell: rejected at build time as incompatible with `cacheComponents`.
- Tried awaiting `searchParams` directly in the page body (outside any
  Suspense boundary) to validate before any streaming starts: fails the
  prerender for the same reason — cacheComponents requires request-data reads
  to happen behind Suspense, which is necessarily after the shell flushes.
- Conclusion: on this route, with cacheComponents enabled, a real 404 status
  is not achievable without disabling cacheComponents project-wide, which is
  out of scope here. This PR settles for the weaker (but real) fallback:
  noindex (already shipped in the SEO PR) plus not paying for the wasted
  WarcraftLogs call — this PR is about the latter.

## Test plan
- [x] `pnpm test`, `pnpm exec eslint src`, `pnpm exec tsc --noEmit` all clean
- [x] Verified with WCL responses stubbed (reverted, not in this diff):
      `?partition=1&encounter=999999` — confirmed in logs that the WCL
      rankings query is NOT called for the bogus encounter, whereas before
      this fix it was
- [ ] Would be good to re-verify the `curl -i` 200-vs-404 finding once real
      WCL_CLIENT_ID/WCL_CLIENT_SECRET are available, in case behavior differs
      with real data — I don't expect it to, since the mechanism is about
      cacheComponents/PPR shell timing, not the data itself

---
_Generated by [Claude Code](https://claude.ai/code/session_01T34Mkgi8nC3cbG5FGxEBu1)_