### PR TITLE
Address review feedback on the filter loading indicator (#203)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,18 +16,13 @@ select {
     @apply rounded-md;
 }
 
-/* While a filter navigation is in flight the dropdowns are disabled. A plain,
- * static dim reads as inactive without the distraction of motion or a
- * misleading "forbidden" cursor. */
-select:disabled {
-    @apply opacity-60;
-}
-
 input {
     @apply p-1;
     @apply rounded-md;
 }
 
-input:disabled {
+select:disabled,
+input:disabled,
+button:disabled {
     @apply opacity-60;
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,6 @@ export default function Button({
             type="button"
             className={twMerge(
                 "rounded-md bg-zinc-700 p-2 hover:bg-zinc-600",
-                "disabled:opacity-60",
                 className,
             )}
             {...props}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -9,7 +9,7 @@ export default function Button({
         <button
             type="button"
             className={twMerge(
-                "rounded-md bg-zinc-700 p-2 hover:bg-zinc-600",
+                "rounded-md bg-zinc-700 p-2 enabled:hover:bg-zinc-600",
                 className,
             )}
             {...props}

--- a/src/components/DropdownFilter.tsx
+++ b/src/components/DropdownFilter.tsx
@@ -22,10 +22,6 @@ export default function DropdownFilter({
     setSelected,
 }: DropdownFilterProps) {
     const [localState, setLocalState] = useState(selected);
-    // While any filter navigation is in flight, lock every dropdown. This both
-    // signals that the page is loading and avoids a race: a second change would
-    // build its URL from the not-yet-committed search params and clobber the
-    // first change.
     const { isPending } = useNavigationTransition();
 
     const onChange: ReactEventHandler<HTMLSelectElement> = (e) => {

--- a/src/components/ItemPicker/ItemFilter.tsx
+++ b/src/components/ItemPicker/ItemFilter.tsx
@@ -38,7 +38,7 @@ export default function ItemFilter({
         >
             <button
                 type="button"
-                className="absolute right-1 top-1 disabled:opacity-60"
+                className="absolute right-1 top-1"
                 onClick={() => itemFilterChange(null, true)}
                 disabled={disabled}
             >

--- a/src/components/ItemPicker/ItemPicker.tsx
+++ b/src/components/ItemPicker/ItemPicker.tsx
@@ -2,6 +2,7 @@
 
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
+import { useNavigationTransition } from "^/lib/NavigationTransition";
 import { useParsedParams } from "^/lib/useParsedParams";
 import { arrayEquals } from "^/lib/utils";
 import Button from "../Button";
@@ -10,7 +11,8 @@ import ItemFilter, { type ItemFilterConfig } from "./ItemFilter";
 export interface ItemPickerProps extends ComponentProps<"div"> {}
 
 export default function ItemPicker({ className, ...props }: ItemPickerProps) {
-    const { setParams, itemFilters, isPending } = useParsedParams();
+    const { setParams, itemFilters } = useParsedParams();
+    const { isPending } = useNavigationTransition();
     const [localFilters, setLocalFilters] =
         useState<ItemFilterConfig[]>(itemFilters);
     const [autofocus, setAutofocus] = useState(false);

--- a/src/components/RankingsBoundary.tsx
+++ b/src/components/RankingsBoundary.tsx
@@ -4,23 +4,10 @@ import { type ReactNode, Suspense } from "react";
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 
 export interface RankingsBoundaryProps {
-    /** The (server-rendered) `<Rankings>` element. */
     children: ReactNode;
-    /** The loading placeholder, e.g. `<RankingsFallback />`. */
     fallback: ReactNode;
 }
 
-/**
- * Wraps the rankings results so they show the same loading indicator on a
- * filter change as they do on the initial load.
- *
- * On the first render the `<Suspense>` boundary handles the streaming server
- * render. On a subsequent filter change the App Router keeps the previous
- * (stale) results on screen until the new server components commit, without
- * ever re-triggering the Suspense fallback. To bridge that gap we swap in the
- * fallback while the navigation transition is pending, so the results area
- * looks identical to the initial load until the fresh data arrives.
- */
 export default function RankingsBoundary({
     children,
     fallback,

--- a/src/components/TalentPicker/TalentFilter.tsx
+++ b/src/components/TalentPicker/TalentFilter.tsx
@@ -109,7 +109,7 @@ export default function TalentFilter({
         >
             <button
                 type="button"
-                className="absolute right-1 top-1 disabled:opacity-60"
+                className="absolute right-1 top-1"
                 onClick={() => filterChange(null, true)}
                 disabled={disabled}
             >

--- a/src/components/TalentPicker/TalentPicker.client.tsx
+++ b/src/components/TalentPicker/TalentPicker.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useNavigationTransition } from "^/lib/NavigationTransition";
 import type { NullTalent } from "^/lib/nullGetTalents";
 import { useParsedParams } from "^/lib/useParsedParams";
 import { arrayEquals } from "^/lib/utils";
@@ -14,7 +15,8 @@ export interface TalentPickerClientProps {
 export default function TalentPickerClient({
     talents,
 }: TalentPickerClientProps) {
-    const { talents: paramFilters, setParams, isPending } = useParsedParams();
+    const { talents: paramFilters, setParams } = useParsedParams();
+    const { isPending } = useNavigationTransition();
     const [filters, setFilters] = useState<TalentFilterConfig[]>(paramFilters);
     const [autofocus, setAutofocus] = useState(false);
 

--- a/src/lib/NavigationTransition.tsx
+++ b/src/lib/NavigationTransition.tsx
@@ -9,15 +9,7 @@ import {
 } from "react";
 
 interface NavigationTransition {
-    /**
-     * Whether a navigation started via {@link startTransition} is currently
-     * in flight (the new server components have not committed yet).
-     */
     isPending: boolean;
-    /**
-     * Wraps the navigation so that {@link isPending} stays `true` for the whole
-     * round-trip, from the moment the user acts until the new page commits.
-     */
     startTransition: TransitionStartFunction;
 }
 
@@ -25,13 +17,6 @@ const NavigationTransitionContext = createContext<NavigationTransition | null>(
     null,
 );
 
-/**
- * Shares a single {@link useTransition} across every filter, so that a
- * navigation started by one control (e.g. a dropdown) exposes its pending
- * state to all of them. This lets us disable every filter while data loads and
- * lets the results area show a loading indicator, instead of leaving the page
- * looking frozen while the new server components stream in.
- */
 export function NavigationTransitionProvider({
     children,
 }: {

--- a/src/lib/NavigationTransition.tsx
+++ b/src/lib/NavigationTransition.tsx
@@ -13,10 +13,20 @@ interface NavigationTransition {
     startTransition: TransitionStartFunction;
 }
 
+/**
+ * Shares a single React transition across multiple components so that a
+ * navigation started by one can be observed by all of them.
+ *
+ * `useTransition`'s `isPending` only reflects the transition started by that
+ * specific hook instance — it is not global. This context holds one shared
+ * instance so any consumer can start a navigation and every consumer can see
+ * it is in flight.
+ */
 const NavigationTransitionContext = createContext<NavigationTransition | null>(
     null,
 );
 
+/** Provides {@link NavigationTransitionContext}. Wrap once, above every consumer. */
 export function NavigationTransitionProvider({
     children,
 }: {
@@ -33,6 +43,11 @@ export function NavigationTransitionProvider({
     );
 }
 
+/**
+ * Reads the shared transition.
+ *
+ * @see {@link NavigationTransitionContext}
+ */
 export function useNavigationTransition() {
     const context = useContext(NavigationTransitionContext);
 

--- a/src/lib/useParsedParams.ts
+++ b/src/lib/useParsedParams.ts
@@ -10,7 +10,7 @@ import { createUrl } from "./utils";
 export function useParsedParams() {
     const router = useRouter();
     const searchParams = useSearchParams();
-    const { isPending, startTransition } = useNavigationTransition();
+    const { startTransition } = useNavigationTransition();
 
     const buildUrl = useCallback(
         (params: Partial<ParsedParams>, { canonical = false } = {}) => {
@@ -35,10 +35,6 @@ export function useParsedParams() {
 
     const setParams = useCallback(
         (params: Partial<ParsedParams>) => {
-            // Wrap the navigation in the shared transition so `isPending` stays
-            // `true` until the new server components have streamed in and
-            // committed. Consumers use it to indicate loading and to lock the
-            // filters while data is fetched.
             startTransition(() => {
                 router.replace(buildUrl(params));
             });
@@ -50,6 +46,5 @@ export function useParsedParams() {
         ...parseParams(searchParams),
         buildUrl,
         setParams,
-        isPending,
     };
 }


### PR DESCRIPTION
**This PR fixes issues in #203**, which was merged before review feedback was addressed. #203 added the filter-loading indicator (shared navigation transition, disabled controls while loading, results fallback on filter change); this PR doesn't change that behavior — it only cleans up how it's implemented, per feedback on #203.

## Fixes

- **Comments** — removed every comment added in #203. None survived the "would a dev need this in a year" test; the worst offender in `globals.css` was actively arguing against rejected alternatives (a pulsing animation, a `not-allowed` cursor), which belongs in PR discussion, not the code.
- **Inconsistent `isPending` source** — `useParsedParams` no longer re-exports `isPending`. Every consumer (`DropdownFilter`, `RankingsBoundary`, `TalentPickerClient`, `ItemPicker`) now reads it directly from `useNavigationTransition()`, so there's one source instead of two paths to the same value.
- **Disabled styling split between global CSS and Tailwind classes** — consolidated into a single rule in `globals.css`:
  ```css
  select:disabled,
  input:disabled,
  button:disabled {
      @apply opacity-60;
  }
  ```
  Removed the redundant `disabled:opacity-*` Tailwind classes from `Button` and the two remove (✖) buttons.
- **`NavigationTransition.tsx` had no explanation of purpose** — added a JSDoc on the context explaining why a *shared* transition instance is needed: `useTransition`'s `isPending` only reflects the transition started by that specific hook instance, not globally, so multiple independent components need to read from one shared instance to see each other's navigations. The provider and hook carry short pointers back to it instead of repeating the explanation.

Not changed, with rationale discussed on #203:
- `RankingsBoundary` stays a separate component — `page.tsx` and `Rankings` are both Server Components, so the `isPending` hook can't be inlined into either without breaking the server/client boundary.
- The shared `NavigationTransitionProvider` context stays — `useTransition`'s `isPending` is scoped to the hook instance that started the transition, so without a shared instance only the dropdown a user touched would know a navigation was in flight; the others (and the rankings fallback) would have no way to observe it. This is a documented, unresolved gap in Next.js App Router (no `router.events` equivalent, `useLinkStatus` only covers `<Link>`-triggered navigation within its own subtree) — the shared-context pattern is the community's standard workaround, not an invented one.

## Testing

- `tsc --noEmit`: clean (the one pre-existing error in `Params.test.ts` is unrelated, present on `main`).
- `eslint`: clean.
- `next build`: compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)