### PR TITLE
Deny Claude Code reads of env/secret files by default

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+    "permissions": {
+        "deny": [
+            "Read(**/.npmrc)",
+            "Read(~/.npmrc)",
+            "Read(**/.env)",
+            "Read(**/.env.*)",
+            "Read(**/secrets/**)",
+            "Read(**/.ssh/**)",
+            "Read(**/.aws/**)"
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a checked-in `.claude/settings.json` with a `permissions.deny` block so every developer who clones this repo gets the same baseline: Claude Code's `Read` tool cannot open `.env*`, `.npmrc`, `secrets/**`, `.ssh/**`, or `.aws/**`.
- Mirrors deny rules that already existed in one contributor's personal global `~/.claude/settings.json` — now everyone gets them by default instead of only whoever happened to configure it themselves.
- Scope note: this only blocks Claude's own `Read` tool. It doesn't stop `Bash(cat .env)` or similar shell access — that's a known gap, left for a follow-up if wanted.

## Test plan
- [x] Validated JSON syntax
- [x] Verified `.claude/settings.local.json` (personal, gitignored) is untouched and still ignored by git
- [x] Pre-commit hook (`lint-staged` → oxfmt) ran cleanly on the new file