### PR TITLE
Show a top-of-page loading bar while a navigation is pending

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "downshift": "^9.4.0",
         "lucide-react": "^0.563.0",
         "next": "16.2.12",
+        "nextjs-toploader": "^3.9.17",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "tailwind-merge": "^2.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       next:
         specifier: 16.2.12
         version: 16.2.12(@babel/core@7.29.7)(@types/node@24.10.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8)(react@19.2.8)
+      nextjs-toploader:
+        specifier: ^3.9.17
+        version: 3.9.17(next@16.2.12)(react-dom@19.2.8)(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2733,6 +2736,13 @@ packages:
       sass:
         optional: true
 
+  nextjs-toploader@3.9.17:
+    resolution: {integrity: sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==}
+    peerDependencies:
+      next: '>= 6.0.0'
+      react: '>= 16.0.0'
+      react-dom: '>= 16.0.0'
+
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
@@ -2872,6 +2882,9 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nprogress@0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
   nwsapi@2.2.24:
     resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
@@ -6679,6 +6692,14 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
+  nextjs-toploader@3.9.17(next@16.2.12)(react-dom@19.2.8)(react@19.2.8):
+    dependencies:
+      next: 16.2.12(@babel/core@7.29.7)(@types/node@24.10.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8)(react@19.2.8)
+      nprogress: 0.2.0
+      prop-types: 15.8.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   node-exports-info@1.6.2:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -6697,6 +6718,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nprogress@0.2.0: {}
 
   nwsapi@2.2.24: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { GithubIcon } from "lucide-react";
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
+import NextTopLoader from "nextjs-toploader";
 
 import { NavigationTransitionProvider } from "^/lib/NavigationTransition";
 
@@ -27,6 +28,7 @@ export default async function RootLayout({
     return (
         <html lang="en">
             <body>
+                <NextTopLoader color="#3b82f6" showSpinner={false} />
                 <header className="flex items-end space-x-2 p-4">
                     <Link href="/" className="flex items-end gap-1">
                         <h1 className="text-4xl font-semibold">

--- a/src/components/PageLinks.tsx
+++ b/src/components/PageLinks.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "nextjs-toploader/app";
+import { type MouseEvent, type ReactNode } from "react";
+import { twMerge } from "tailwind-merge";
 
+import { useNavigationTransition } from "^/lib/NavigationTransition";
 import { useParsedParams } from "^/lib/useParsedParams";
 
 export interface PageLinksProps {
@@ -11,32 +15,69 @@ export interface PageLinksProps {
 export default function PageLinks({ showNext }: PageLinksProps) {
     const { page, buildUrl } = useParsedParams();
 
-    const className =
-        "text-blue-500 rounded-sm hover:bg-blue-500 hover:text-white";
-
     return (
         <>
             {page > 1 && (
                 <>
-                    <Link
-                        href={buildUrl({ page: page - 1 })}
-                        rel="nofollow"
-                        className={className}
-                    >
+                    <PageLink href={buildUrl({ page: page - 1 })}>
                         Previous Page
-                    </Link>
+                    </PageLink>
                     &nbsp;
                 </>
             )}
             {showNext ? (
-                <Link
-                    href={buildUrl({ page: page + 1 })}
-                    rel="nofollow"
-                    className={className}
-                >
+                <PageLink href={buildUrl({ page: page + 1 })}>
                     Next Page
-                </Link>
+                </PageLink>
             ) : null}
         </>
+    );
+}
+
+interface PageLinkProps {
+    href: string;
+    children: ReactNode;
+}
+
+function PageLink({ href, children }: PageLinkProps) {
+    const router = useRouter();
+    const { isPending, startTransition } = useNavigationTransition();
+
+    const onClick = (event: MouseEvent<HTMLAnchorElement>) => {
+        if (
+            event.button !== 0 ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey
+        ) {
+            return;
+        }
+
+        event.preventDefault();
+
+        if (isPending) {
+            return;
+        }
+
+        startTransition(() => {
+            router.push(href);
+        });
+    };
+
+    return (
+        <Link
+            href={href}
+            rel="nofollow"
+            onClick={onClick}
+            aria-disabled={isPending}
+            aria-busy={isPending}
+            className={twMerge(
+                "rounded-sm text-blue-500 hover:bg-blue-500 hover:text-white",
+                isPending && "pointer-events-none text-zinc-500",
+            )}
+        >
+            {children}
+        </Link>
     );
 }

--- a/src/lib/useParsedParams.ts
+++ b/src/lib/useParsedParams.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "nextjs-toploader/app";
 import { useCallback } from "react";
 
 import { useNavigationTransition } from "./NavigationTransition";


### PR DESCRIPTION
Follow-up to the filter-locking work. Changing a filter already disabled the pickers and swapped in the rankings fallback, but paging with Next/Previous gave no feedback at all.

## Why paging had no indication

`useParsedParams.setParams` wraps `router.replace` in the shared `NavigationTransition`, so every filter change flips `isPending` and the pickers / `RankingsBoundary` react to it. The page links were plain `<Link>`s — Next.js runs those in its own internal transition, so `isPending` never flipped and nothing observed the navigation.

## Changes

- **`PageLinks`** intercepts the click and runs `router.push` inside the shared transition. It stays a real `<Link>`, so prefetch, `href` and ctrl/cmd-click-to-new-tab still work; only unmodified left-clicks are intercepted. It also renders disabled (`aria-disabled`, `pointer-events-none`, greyed) while pending, and the handler refuses a second click.
- **`useParsedParams` and `PageLinks`** import `useRouter` from `nextjs-toploader/app` instead of `next/navigation`. That is the package's documented hook for programmatic navigation: it calls `NProgress.start()`, and the package's patched `history.pushState`/`replaceState` finish the bar when the RSC payload commits.
- **`layout.tsx`** renders `<NextTopLoader color="#3b82f6" showSpinner={false} />`. The blue matches the existing link colour; the spinner is off because it sits at `top:15px; right:15px` and would land on the GitHub icon in the header.

## Why `nextjs-toploader`

| Package | Weekly downloads | Notes |
|---|---|---|
| `nprogress` | ~3.3M | The recognisable visual, but unmaintained since 2015 and has no Next.js integration |
| **`nextjs-toploader`** | **~285k**, 1.2k★ | nprogress wrapped for the App Router; latest 3.9.17, explicitly supports Next 16 |
| `next-nprogress-bar` | ~93k, 715★ | Deprecated by its author in favour of `@bprogress/next` |
| `@bprogress/next` | smaller | Maintained TS rewrite of nprogress, but last publish Apr 2025 |
| `nextjs-progressbar` | ~88k | Pages Router era |

No single dominant winner, but `nextjs-toploader` is the closest thing to a community default for the App Router.

Worth noting for review: I deliberately avoided bridging `isPending` to `start()`/`done()` with an effect. `useTopLoader()` returns a fresh object on every render, so such an effect re-runs constantly and can kill a bar that the package's own click handler started (for example the header logo link).

## Verification

Ran the dev server against a temporary route (since deleted) that used the real `PageLinks`, `DropdownFilter` and `useParsedParams` against a 2.5s server component, sampling the DOM through the transition:

```
t=  317ms bar=9%   pending=PENDING  url=
t= 1376ms bar=14%  pending=PENDING  url=
t= 2433ms bar=18%  pending=PENDING  url=
t= 2699ms bar=84%  pending=IDLE     url=?page=2
t= 3219ms bar=gone pending=IDLE     url=?page=2
```

The bar starts on click, crawls for the whole wait and completes exactly when the content lands. Mid-transition the `<select>` reported `disabled: true` and the links `aria-disabled="true"` with the greyed class, for both the Next-Page path and the filter path.

`pnpm run lint` and `pnpm run test` (34 tests) pass. `pnpm run build` compiles and typechecks cleanly; it cannot finish prerendering `/` in my environment because `WCL_CLIENT_ID`/`WCL_CLIENT_SECRET` are unset, which is unrelated to this diff.

## Open question

The disabled state on the page links is close to unreachable in practice: `PageLinks` renders inside `Rankings`, and `RankingsBoundary` swaps the whole block for `RankingsFallback` while pending — so the links disappear rather than grey out. That still satisfies "can't click next twice", but the page counter and controls vanish and the layout jumps on every filter change. If they should stay put and dim instead, that is a change to `RankingsBoundary`/`RankingsFallback` and can be a follow-up. The guard in `PageLink` is kept regardless, since it is cheap and correct independent of what the boundary does.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HA3MPkkHfYQJjDUNisMrwh)_