### PR TITLE
Improve navigation feel with Next.js 16.3 Instant Navigations

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
     },
     reactCompiler: true,
     cacheComponents: true,
+    partialPrefetching: true,
     cacheLife: {
         /**
          * Represents caching for things that doesn't change until a new expansion is released.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,41 @@
         @apply opacity-60;
     }
 }
+
+@keyframes stale-dim {
+    to {
+        opacity: 0.6;
+    }
+}
+
+.stale-dim {
+    animation: stale-dim 150ms ease-in;
+    animation-delay: 120ms;
+    animation-fill-mode: forwards;
+}
+
+@keyframes nav-progress-appear {
+    to {
+        opacity: 1;
+    }
+}
+
+.nav-progress {
+    opacity: 0;
+    animation: nav-progress-appear 1ms linear;
+    animation-delay: 120ms;
+    animation-fill-mode: forwards;
+}
+
+@keyframes nav-progress-slide {
+    from {
+        transform: translateX(-100%);
+    }
+    to {
+        transform: translateX(350%);
+    }
+}
+
+.nav-progress-bar {
+    animation: nav-progress-slide 1s ease-in-out infinite;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { GithubIcon } from "lucide-react";
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
 
+import NavigationProgress from "^/components/NavigationProgress";
 import { NavigationTransitionProvider } from "^/lib/NavigationTransition";
 
 import "./globals.css";
@@ -62,6 +63,7 @@ export default async function RootLayout({
                     </a>
                 </header>
                 <NavigationTransitionProvider>
+                    <NavigationProgress />
                     {children}
                 </NavigationTransitionProvider>
                 <Analytics />

--- a/src/components/ItemPicker/ItemFilter.tsx
+++ b/src/components/ItemPicker/ItemFilter.tsx
@@ -48,7 +48,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 autoFocus={autofocus}
                 value={itemFilter.name}
                 onChange={(e) =>
@@ -65,7 +64,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 value={itemFilter.id}
                 onChange={(e) =>
                     itemFilterChange(
@@ -81,7 +79,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 value={itemFilter.permanentEnchant}
                 onChange={(e) =>
                     itemFilterChange(
@@ -97,7 +94,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 value={itemFilter.temporaryEnchant}
                 onChange={(e) =>
                     itemFilterChange(
@@ -113,7 +109,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 value={itemFilter.bonusId}
                 onChange={(e) =>
                     itemFilterChange(
@@ -129,7 +124,6 @@ export default function ItemFilter({
             <input
                 type="text"
                 className="rounded-md border border-gray-200"
-                disabled={disabled}
                 value={itemFilter.gemId}
                 onChange={(e) =>
                     itemFilterChange(

--- a/src/components/NavigationPending.tsx
+++ b/src/components/NavigationPending.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useLinkStatus } from "next/link";
+import { useEffect } from "react";
+
+import { useNavigationTransition } from "^/lib/NavigationTransition";
+
+/**
+ * Reports a `<Link>`'s pending state into {@link useNavigationTransition},
+ * so link clicks show the same loading feedback as `setParams` navigations.
+ *
+ * Must be rendered as a descendant of the `<Link>` it tracks.
+ */
+export default function NavigationPending() {
+    const { pending } = useLinkStatus();
+    const { setLinkPending } = useNavigationTransition();
+
+    useEffect(() => {
+        if (!pending) {
+            return;
+        }
+
+        setLinkPending(true);
+        return () => setLinkPending(false);
+    }, [pending, setLinkPending]);
+
+    return null;
+}

--- a/src/components/NavigationProgress.tsx
+++ b/src/components/NavigationProgress.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useNavigationTransition } from "^/lib/NavigationTransition";
+
+export default function NavigationProgress() {
+    const { isPending } = useNavigationTransition();
+
+    return (
+        <div
+            aria-hidden
+            className={
+                isPending
+                    ? "nav-progress fixed inset-x-0 top-0 z-50 h-0.5 overflow-hidden"
+                    : "hidden"
+            }
+        >
+            <div className="nav-progress-bar h-full w-2/5 bg-blue-500" />
+        </div>
+    );
+}

--- a/src/components/PageLinks.tsx
+++ b/src/components/PageLinks.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 
 import { useParsedParams } from "^/lib/useParsedParams";
+
+import NavigationPending from "./NavigationPending";
 
 export interface PageLinksProps {
     showNext: boolean;
@@ -10,6 +13,8 @@ export interface PageLinksProps {
 
 export default function PageLinks({ showNext }: PageLinksProps) {
     const { page, buildUrl } = useParsedParams();
+    const [prevActive, setPrevActive] = useState(false);
+    const [nextActive, setNextActive] = useState(false);
 
     const className =
         "text-blue-500 rounded-xs hover:bg-blue-500 hover:text-white";
@@ -22,8 +27,12 @@ export default function PageLinks({ showNext }: PageLinksProps) {
                         href={buildUrl({ page: page - 1 })}
                         rel="nofollow"
                         className={className}
+                        prefetch={prevActive ? true : false}
+                        onMouseEnter={() => setPrevActive(true)}
+                        onFocus={() => setPrevActive(true)}
                     >
                         Previous Page
+                        <NavigationPending />
                     </Link>
                     &nbsp;
                 </>
@@ -33,8 +42,12 @@ export default function PageLinks({ showNext }: PageLinksProps) {
                     href={buildUrl({ page: page + 1 })}
                     rel="nofollow"
                     className={className}
+                    prefetch={nextActive ? true : false}
+                    onMouseEnter={() => setNextActive(true)}
+                    onFocus={() => setNextActive(true)}
                 >
                     Next Page
+                    <NavigationPending />
                 </Link>
             ) : null}
         </>

--- a/src/components/RankingsBoundary.tsx
+++ b/src/components/RankingsBoundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type ReactNode, Suspense } from "react";
+import { twMerge } from "tailwind-merge";
 
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 
@@ -17,7 +18,12 @@ export default function RankingsBoundary({
 
     return (
         <Suspense fallback={fallback}>
-            {isPending ? fallback : children}
+            <div
+                aria-busy={isPending}
+                className={twMerge(isPending && "stale-dim")}
+            >
+                {children}
+            </div>
         </Suspense>
     );
 }

--- a/src/components/TalentPicker/TalentFilter.tsx
+++ b/src/components/TalentPicker/TalentFilter.tsx
@@ -114,11 +114,7 @@ export default function TalentFilter({
                 ✖
             </button>
             Talent Name 🔎{" "}
-            <input
-                type="text"
-                list="talentlist"
-                {...getInputProps({ disabled })}
-            />
+            <input type="text" list="talentlist" {...getInputProps()} />
             <div className="relative">
                 <ul
                     className={twMerge(
@@ -149,7 +145,6 @@ export default function TalentFilter({
             <input
                 type="text"
                 value={filter.talentId}
-                disabled={disabled}
                 onChange={(e) =>
                     filterChange({
                         name: filter.name,

--- a/src/lib/NavigationTransition.tsx
+++ b/src/lib/NavigationTransition.tsx
@@ -4,13 +4,17 @@ import {
     createContext,
     type ReactNode,
     type TransitionStartFunction,
+    useCallback,
     useContext,
+    useMemo,
+    useState,
     useTransition,
 } from "react";
 
 interface NavigationTransition {
     isPending: boolean;
     startTransition: TransitionStartFunction;
+    setLinkPending: (pending: boolean) => void;
 }
 
 /**
@@ -21,6 +25,10 @@ interface NavigationTransition {
  * specific hook instance — it is not global. This context holds one shared
  * instance so any consumer can start a navigation and every consumer can see
  * it is in flight.
+ *
+ * `setLinkPending` folds in `<Link>` navigations (tracked separately via
+ * `useLinkStatus`, see `NavigationPending`) so `isPending` reflects both
+ * `router.replace` transitions and plain link clicks.
  */
 const NavigationTransitionContext = createContext<NavigationTransition | null>(
     null,
@@ -32,12 +40,29 @@ export function NavigationTransitionProvider({
 }: {
     children: ReactNode;
 }) {
-    const [isPending, startTransition] = useTransition();
+    const [isTransitionPending, startTransition] = useTransition();
+    const [pendingLinkCount, setPendingLinkCount] = useState(0);
+
+    const setLinkPending = useCallback((pending: boolean) => {
+        setPendingLinkCount((count) => count + (pending ? 1 : -1));
+    }, []);
+
+    const value = useMemo(
+        (): NavigationTransition => ({
+            isPending: isTransitionPending || pendingLinkCount > 0,
+            startTransition,
+            setLinkPending,
+        }),
+        [
+            isTransitionPending,
+            pendingLinkCount,
+            startTransition,
+            setLinkPending,
+        ],
+    );
 
     return (
-        <NavigationTransitionContext.Provider
-            value={{ isPending, startTransition }}
-        >
+        <NavigationTransitionContext.Provider value={value}>
             {children}
         </NavigationTransitionContext.Provider>
     );


### PR DESCRIPTION
## Summary

Following the upgrade to Next.js 16.3, this adopts [Instant Navigations](https://nextjs.org/blog/next-16-3-instant-navigations) to address the long-standing navigation-feel issue from #203/#220, and cleans up the previous workaround now that a better primitive exists.

- Enable `partialPrefetching` alongside `cacheComponents` — `<Link>` now prefetches a shared App Shell per route instead of a full per-link prefetch.
- Unify the pending signal across both navigation mechanisms in the app: filter changes (`router.replace` via `useParsedParams`) and pagination (plain `<Link>`). A new `NavigationPending` component wraps `useLinkStatus` and feeds link-click pending state into the existing shared `NavigationTransition` context, so Prev/Next now shows loading feedback for the first time.
- Replace `RankingsBoundary`'s destructive skeleton swap (from #203) with a non-destructive dim: stale results stay visible and readable, with `aria-busy` and a 120ms-delayed opacity animation, so navigations that resolve before the delay (warm cache, prefetched) never flash a loading state. Verified a warm-cache revisit resolves in ~56ms vs. ~1.3–1.5s cold.
- Add a global top progress bar (`NavigationProgress`, the idea from draft #220) driven by the same unified signal and delay.
- Prefetch pagination links at runtime only on hover/focus intent (not viewport), since each runtime prefetch costs a server invocation and a remote-cache read.
- Drop `disabled` from `ItemFilter`/`TalentFilter` text inputs so a pending navigation no longer interrupts typing or steals focus. Buttons and dropdowns keep it since remounting them mid-transition is harmless.

`ISR`/`generateStaticParams` was considered but is not applicable here — all state lives in `searchParams` on a single route, which ISR doesn't cover; runtime prefetching is the relevant 16.3 feature for this app's shape instead.

## Known follow-up

`generateMetadata` in `src/app/(main)/page.tsx` reads `searchParams` directly to include the result count in the `<title>`. Per the Next.js docs this pattern unconditionally surfaces an Instant Insights blocking-metadata warning in dev. Left untouched pending a decision on whether to keep the count (optionally silencing with `instant = false`) or drop it to fully decouple metadata from the rankings fetch.

## Test plan

- [x] `pnpm run lint` — passes (3 pre-existing-pattern warnings for new custom CSS animation classnames, 0 errors)
- [x] `pnpm run test` — 68/68 passing
- [x] `pnpm run build` — succeeds, `/` and `/talents/[classId]/[specId]` show as Partial Prerender
- [x] `pnpm run build && pnpm run start` — sanity-checked via curl: cold rankings fetch ~1.3–1.5s, warm cache hit ~56ms
- [ ] Manual browser check: dropdown filter change dims results without skeleton flash; hover Prev/Next then click is instant; click Next without hovering shows progress bar + dim

🤖 Generated with [Claude Code](https://claude.com/claude-code)