### PR TITLE
Revert from Oxfmt back to Prettier

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # Reformat imports with oxfmt sortImports
 7d25966545a1444faab5afdbd678c7cc6015937d
+
+# Reformat with the restored ESLint rules
+c452880e217ae5bf91a5110f5268c2c12d3186c8

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,7 +1,0 @@
-{
-    "$schema": "./node_modules/oxfmt/configuration_schema.json",
-    "sortPackageJson": false,
-    "sortImports": {
-        "internalPattern": ["^/"]
-    }
-}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,0 @@
-{
-    "recommendations": ["oxc.oxc-vscode", "dbaeumer.vscode-eslint"],
-    "unwantedRecommendations": ["esbenp.prettier-vscode"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,15 @@
 {
     "js/ts.tsdk.path": "node_modules/typescript/lib",
-    "oxc.enable.oxfmt": true,
+    "oxc.enable.oxfmt": false,
     "oxc.enable.oxlint": false,
     "eslint.enable": true,
-    "prettier.enable": false,
-    "editor.defaultFormatter": "oxc.oxc-vscode"
+    "prettier.enable": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "eslint.format.enable": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Warcraftlogs Search (hosted at wcl.nulldozzer.io) helps users find specific Warc
     pnpm run lint
     ```
 
-    This runs ESLint on all `.ts`/`.tsx` files, then Oxfmt (`--check`) on all supported files (`.ts`/`.tsx`/`.js`/`.css`/`.md`/`.yml`/`.yaml`/`.json`). Both must pass.
+    This runs ESLint (which also checks Prettier formatting) on all `.ts`/`.tsx`/`.js`/`.jsx` files, then Prettier directly on `.css`/`.md`/`.yml`/`.yaml`/`.json` files. Both must pass.
 
 3. **Auto-fix linting issues** (use when lint fails):
 
@@ -39,7 +39,7 @@ Warcraftlogs Search (hosted at wcl.nulldozzer.io) helps users find specific Warc
     pnpm run lint-fix
     ```
 
-    Auto-fixes ESLint issues and reformats with Oxfmt where possible. You must still fix any remaining errors manually (e.g., unused variables).
+    Auto-fixes ESLint issues and reformats `.css`/`.md`/`.yml`/`.yaml`/`.json` files with Prettier where possible. You must still fix any remaining errors manually (e.g., unused variables).
 
 4. **Run tests** (required before committing):
 
@@ -112,7 +112,7 @@ warcraftlogs-search/
 4. Sibling imports
 5. Index imports
 
-**Formatting** (enforced by Oxfmt + EditorConfig):
+**Formatting** (enforced by Prettier + EditorConfig):
 
 - Indent: 4 spaces
 - Max line length: 80 characters

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # warcraftlogs-search
 
 [![Powered by Vercel](https://badgen.net/badge/vercel/warcraftlogs-search/black?icon=zeit)](https://wcl.nulldozzer.io/)
-[![code style: oxfmt](https://img.shields.io/badge/code_style-oxfmt-5c6bc0.svg)](https://oxc.rs/docs/guide/usage/formatter)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 > Tool for finding logs using certain talents and/or items
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,10 +3,6 @@ import nextObusk from "@obusk/eslint-config-next";
 const eslintConfig = [
     ...nextObusk,
     {
-        rules: {
-            "prettier/prettier": "off",
-            "import-x/order": "off",
-        },
         settings: {
             react: { version: "19" },
             tailwindcss: {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,10 @@
     },
     "lint-staged": {
         "**/*.{ts,tsx,js,jsx,mjs,cjs}": [
-            "eslint --fix",
-            "oxfmt"
+            "eslint --fix"
         ],
         "**/*.{css,md,yml,yaml,json}": [
-            "oxfmt"
+            "prettier --write"
         ]
     },
     "scripts": {
@@ -47,11 +46,11 @@
         "typegen": "next typegen",
         "prelint": "pnpm run typegen",
         "lint": "eslint .",
-        "postlint": "pnpm run format-check",
+        "postlint": "pnpm run prettier",
         "lint-fix": "eslint --fix .",
-        "postlint-fix": "pnpm run format",
-        "format": "oxfmt",
-        "format-check": "oxfmt --check",
+        "postlint-fix": "pnpm run prettier-fix",
+        "prettier": "prettier **/*.{css,md,yml,yaml,json} --ignore-path .gitignore --ignore-path .prettierignore --check",
+        "prettier-fix": "prettier **/*.{css,md,yml,yaml,json} --ignore-path .gitignore --ignore-path .prettierignore --write",
         "lint-staged": "lint-staged",
         "test": "jest",
         "test-ci": "jest --ci"
@@ -81,7 +80,6 @@
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "lint-staged": "^17.3.0",
-        "oxfmt": "^0.61.0",
         "postcss": "^8.5.25",
         "prettier": "^3.9.6",
         "simple-git-hooks": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       node:
         specifier: runtime:^24.19.0
         version: runtime:24.19.0
-      oxfmt:
-        specifier: ^0.61.0
-        version: 0.61.0
       postcss:
         specifier: ^8.5.25
         version: 8.5.25
@@ -794,128 +791,6 @@ packages:
       prettier: '>=3.9.0'
       tailwindcss: ^4.2.0
       typescript: ~6.0.3
-
-  '@oxfmt/binding-android-arm-eabi@0.61.0':
-    resolution: {integrity: sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
-  '@oxfmt/binding-android-arm64@0.61.0':
-    resolution: {integrity: sha512-of8atAV0M1egGcVOMbgZCvc10sFOP3ayQBNQV5h5G3fNq8gACdEswfFk9bzGrdbM23rtg0Coxi7np7oPLcueNw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@oxfmt/binding-darwin-arm64@0.61.0':
-    resolution: {integrity: sha512-7l8+5ov4BGwtAcmpzvEik/TG3bciwyw/S3e6j5GKH7pcQqcgCVxD3AuJeP6upto+SOTBKQ4wrrdbMt0gq8fHSQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxfmt/binding-darwin-x64@0.61.0':
-    resolution: {integrity: sha512-Fnz4dDDXBb7udk+DmwelNjxbD6yptyxwCqwCH2ebo4RVLxVsRfFsn/AHJC49KIltPrVokamGv4SSOsiV50DTxQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxfmt/binding-freebsd-x64@0.61.0':
-    resolution: {integrity: sha512-mddOebKNCP+AucmzfNsk3jgbr681qAUvgMqi865GW5gWLJ/AnzXbvjQRrny0e++NAN8aphav/aRSrfFxNsNjpA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
-    resolution: {integrity: sha512-svx59iYL+DbaZGZUIoice4W0CjRXGExnbz7Re+awIb60rVxBS2KrU7Hnlx+nZYanLGLpjneUEgo/VFEKkSZAyQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
-    resolution: {integrity: sha512-BYK9MPJPCf6d+fLKMTruThmEyCtHzQ1zLcsrTlUVkmnoXIaHAbfpeLYQwX1tkjs7W11dyzoi6HFvKcdnvX1zNg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
-    resolution: {integrity: sha512-QUaCNLq2/EC6G5ljOuFanl9Lgw6ZWp4co7rs4+KOMUzbGfA4Lq58FHRjjF9sVIG+93XSbo343MxFATrOU1qctA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-arm64-musl@0.61.0':
-    resolution: {integrity: sha512-S6uvJ6MXnRXl+zTs0CARNDvkE+cymj0EVWEKKsyKnlLlqTyQJBjw5s4D2pSIOZc+S46cy4STefzcr/sm0VzVPA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
-    resolution: {integrity: sha512-6VDlRcytvZG6UlSIdAFKDLbppo9tvPxrWzle6vHldYFMeuDPQEfMKrkwezp7FaBq1wik9ra554ZZeRPsyIkFpg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
-    resolution: {integrity: sha512-KkBTYbzExpbmn15XjKPLu2fRV2PVlq+KWt+brad5rwIa03vdYoaDRWiS7raHII/dCTR6Ro4UpYUCH4t6lif4WQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
-    resolution: {integrity: sha512-69tzIq7sJLVB9dxYYtvMzcSSsnZHSO+U2U19O2RqDqgj6+Q4O7HjSXdaszbcgqzhsUwzSH7z5kWvk8nmf6BHTg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
-    resolution: {integrity: sha512-Oqi/N0OvtOVXsPKAOOhKgGH3msRYF8BLJaNBbWiupRiKoKVyc8JRKPCfarkQJC+RgP9U8raUKLe+bNwd0HUMiA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-x64-gnu@0.61.0':
-    resolution: {integrity: sha512-3TKwv/ed4uwJSemAA8P9XcoqETpjQI4waquF9UilhA9Mn/dhr1PdUEXWlL74mtc6ZNfmKPA9+NEJm01nRF8CVA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@oxfmt/binding-linux-x64-musl@0.61.0':
-    resolution: {integrity: sha512-uFso4u4nLkVSlMCpgjyvWV60Gt7GvDQHnk1mmRxHIkZTMB0ljpUKwCD9FYGgN9H97x2wYl0UwEjgRZaPIuhEhw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxfmt/binding-openharmony-arm64@0.61.0':
-    resolution: {integrity: sha512-keGLkzeOvkMpNmPp4hffXWpfoSsY6e1K8++KXD4mSSfxdvM8q9QUDsYY689TB1k6Co832DZn1MnaaVx6cIBMWQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
-    resolution: {integrity: sha512-VzsAISkFxmNhJ5LBDEL9VuH6tJsVJMtqYit2LyIUf/HLnsCe4Pg9SMOjjVQzGWt0bnpyfJ94CrqTqcpNZzK+ug==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
-    resolution: {integrity: sha512-xv4t7yzwJoYaLB6Zv28B3W+j7brEjsyv50rLTAQgmxJzddce9fAMCxed8dSAkbWES0zz2J29nYK5FaTuD2YBHg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@oxfmt/binding-win32-x64-msvc@0.61.0':
-    resolution: {integrity: sha512-6EZXFkqOwxdDYjIn3TSNnPk3ST5E5GiYd4FiM6UF/mCL/LZSfr6D6UygTfW3R1PCQP2quCKpCEGRlij8E3VYbg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3048,19 +2923,6 @@ packages:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
 
-  oxfmt@0.61.0:
-    resolution: {integrity: sha512-DxdHBEMYpcEnHoUHjjOigUqV2TYKsvxLwUPXnVYBjgFdqrcQ/91OtwubtZ2PUodCs3sStI8R5Qw3fKNGK4e8wQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      svelte: ^5.0.0
-      vite-plus: '*'
-    peerDependenciesMeta:
-      svelte:
-        optional: true
-      vite-plus:
-        optional: true
-
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3524,10 +3386,6 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
-
-  tinypool@2.1.0:
-    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
-    engines: {node: ^20.0.0 || >=22.0.0}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -4503,63 +4361,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - eslint-plugin-import
       - supports-color
-
-  '@oxfmt/binding-android-arm-eabi@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-android-arm64@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-darwin-arm64@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-darwin-x64@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-freebsd-x64@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm-gnueabihf@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm-musleabihf@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm64-gnu@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-arm64-musl@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-ppc64-gnu@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-riscv64-gnu@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-riscv64-musl@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-s390x-gnu@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-x64-gnu@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-linux-x64-musl@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-openharmony-arm64@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-win32-arm64-msvc@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-win32-ia32-msvc@0.61.0':
-    optional: true
-
-  '@oxfmt/binding-win32-x64-msvc@0.61.0':
-    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6897,30 +6698,6 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxfmt@0.61.0:
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.61.0
-      '@oxfmt/binding-android-arm64': 0.61.0
-      '@oxfmt/binding-darwin-arm64': 0.61.0
-      '@oxfmt/binding-darwin-x64': 0.61.0
-      '@oxfmt/binding-freebsd-x64': 0.61.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.61.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.61.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.61.0
-      '@oxfmt/binding-linux-arm64-musl': 0.61.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.61.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.61.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.61.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.61.0
-      '@oxfmt/binding-linux-x64-gnu': 0.61.0
-      '@oxfmt/binding-linux-x64-musl': 0.61.0
-      '@oxfmt/binding-openharmony-arm64': 0.61.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.61.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.61.0
-      '@oxfmt/binding-win32-x64-msvc': 0.61.0
-
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -7425,8 +7202,6 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-
-  tinypool@2.1.0: {}
 
   tldts-core@6.1.86: {}
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,7 +1,6 @@
 import { type Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-
 import CanonicalFooter from "^/components/CanonicalFooter";
 import ClassPickers from "^/components/ClassPickers";
 import ItemPicker, {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,9 +2,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { GithubIcon } from "lucide-react";
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
-
 import { NavigationTransitionProvider } from "^/lib/NavigationTransition";
-
 import "./globals.css";
 
 export const viewport: Viewport = {

--- a/src/app/raidbots/page.tsx
+++ b/src/app/raidbots/page.tsx
@@ -1,5 +1,4 @@
 import { cacheLife } from "next/cache";
-
 import { getTalentTrees } from "^/lib/raidbots/getTalentTrees";
 
 export default async function Raidbots() {

--- a/src/app/talents/[classId]/[specId]/page.tsx
+++ b/src/app/talents/[classId]/[specId]/page.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from "react";
-
 import { Inspect } from "^/components/Inspect";
 import { nullGetTalents } from "^/lib/nullGetTalents";
 

--- a/src/components/CanonicalFooter.tsx
+++ b/src/components/CanonicalFooter.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { twMerge } from "tailwind-merge";
-
 import { type RawParams } from "^/lib/Params";
 import { generateCanonicalUrl } from "^/lib/seo-utils";
 

--- a/src/components/ClassPickers/ClassPicker.tsx
+++ b/src/components/ClassPickers/ClassPicker.tsx
@@ -2,7 +2,6 @@
 
 import { useParsedParams } from "^/lib/useParsedParams";
 import { type Klass } from "^/lib/wcl/classes";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface ClassPickerProps {

--- a/src/components/ClassPickers/ClassPickers.tsx
+++ b/src/components/ClassPickers/ClassPickers.tsx
@@ -1,7 +1,5 @@
 import { type ComponentProps } from "react";
-
 import { getGameData } from "^/lib/wcl/gameData";
-
 import ClassPicker from "./ClassPicker";
 import SpecPicker from "./SpecPicker";
 

--- a/src/components/ClassPickers/SpecPicker.tsx
+++ b/src/components/ClassPickers/SpecPicker.tsx
@@ -3,7 +3,6 @@
 import { MalformedUrlParameterError } from "^/lib/Errors";
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Klass } from "^/lib/wcl/classes";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface SpecPickerProps {

--- a/src/components/DropdownFilter.tsx
+++ b/src/components/DropdownFilter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type ReactEventHandler, useState } from "react";
-
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 
 interface Option {

--- a/src/components/ItemPicker/ItemPicker.tsx
+++ b/src/components/ItemPicker/ItemPicker.tsx
@@ -2,11 +2,9 @@
 
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
-
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 import { useParsedParams } from "^/lib/useParsedParams";
 import { arrayEquals } from "^/lib/utils";
-
 import Button from "../Button";
 import ItemFilter, { type ItemFilterConfig } from "./ItemFilter";
 

--- a/src/components/PageLinks.tsx
+++ b/src/components/PageLinks.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-
 import { useParsedParams } from "^/lib/useParsedParams";
 
 export interface PageLinksProps {

--- a/src/components/Rankings.tsx
+++ b/src/components/Rankings.tsx
@@ -1,13 +1,11 @@
 import { notFound } from "next/navigation";
 import { type ComponentProps } from "react";
 import { twMerge } from "tailwind-merge";
-
 import { isNotFoundError } from "^/lib/Errors";
 import { type ParsedParams, parseParams, type RawParams } from "^/lib/Params";
 import { buildWclUrl } from "^/lib/utils";
 import { getGameData } from "^/lib/wcl/gameData";
 import getRankings, { type NullCharacterRankings } from "^/lib/wcl/rankings";
-
 import PageLinks from "./PageLinks";
 
 export interface RankingsProps extends ComponentProps<"div"> {

--- a/src/components/RankingsBoundary.tsx
+++ b/src/components/RankingsBoundary.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type ReactNode, Suspense } from "react";
-
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 
 export interface RankingsBoundaryProps {

--- a/src/components/TalentPicker/TalentFilter.tsx
+++ b/src/components/TalentPicker/TalentFilter.tsx
@@ -3,7 +3,6 @@
 import { useCombobox, type UseComboboxStateChange } from "downshift";
 import { type ComponentProps, useCallback, useState } from "react";
 import { twMerge } from "tailwind-merge";
-
 import { type NullTalent } from "^/lib/nullGetTalents";
 
 export interface TalentFilterConfig {

--- a/src/components/TalentPicker/TalentPicker.client.tsx
+++ b/src/components/TalentPicker/TalentPicker.client.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
 import { useNavigationTransition } from "^/lib/NavigationTransition";
 import type { NullTalent } from "^/lib/nullGetTalents";
 import { useParsedParams } from "^/lib/useParsedParams";
 import { arrayEquals } from "^/lib/utils";
-
 import Button from "../Button";
 import TalentFilter, { type TalentFilterConfig } from "./TalentFilter";
 

--- a/src/components/TalentPicker/TalentPicker.tsx
+++ b/src/components/TalentPicker/TalentPicker.tsx
@@ -1,8 +1,6 @@
 import { type ComponentProps } from "react";
-
 import { nullGetTalents } from "^/lib/nullGetTalents";
 import { parseParams, type RawParams } from "^/lib/Params";
-
 import Button from "../Button";
 import TalentPickerClient from "./TalentPicker.client";
 

--- a/src/components/ZonePickers/DifficultyPicker.tsx
+++ b/src/components/ZonePickers/DifficultyPicker.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import Link from "next/link";
-
 import { useParsedParams } from "^/lib/useParsedParams";
 import { type Zone } from "^/lib/wcl/zones";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface DifficultyPickerProps {

--- a/src/components/ZonePickers/EncounterPicker.tsx
+++ b/src/components/ZonePickers/EncounterPicker.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import Link from "next/link";
-
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Zone } from "^/lib/wcl/zones";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface EncounterPickerProps {

--- a/src/components/ZonePickers/MetricPicker.tsx
+++ b/src/components/ZonePickers/MetricPicker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useParsedParams } from "^/lib/useParsedParams";
-
 import DropdownFilter from "../DropdownFilter";
 
 export default function MetricPicker() {

--- a/src/components/ZonePickers/PartitionPicker.tsx
+++ b/src/components/ZonePickers/PartitionPicker.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import Link from "next/link";
-
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Zone } from "^/lib/wcl/zones";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface PartitionPickerProps {

--- a/src/components/ZonePickers/RegionPicker.tsx
+++ b/src/components/ZonePickers/RegionPicker.tsx
@@ -2,7 +2,6 @@
 
 import { useParsedParams } from "^/lib/useParsedParams";
 import { type Region } from "^/lib/wcl/regions";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface RegionPickerProps {

--- a/src/components/ZonePickers/ZonePicker.tsx
+++ b/src/components/ZonePickers/ZonePicker.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import Link from "next/link";
-
 import { useParsedParams } from "^/lib/useParsedParams";
 import type { Zone } from "^/lib/wcl/zones";
-
 import DropdownFilter from "../DropdownFilter";
 
 export interface ZonePickerProps {

--- a/src/components/ZonePickers/ZonePickers.tsx
+++ b/src/components/ZonePickers/ZonePickers.tsx
@@ -1,7 +1,5 @@
 import { type ComponentProps } from "react";
-
 import { getGameData } from "^/lib/wcl/gameData";
-
 import DifficultyPicker from "./DifficultyPicker";
 import EncounterPicker from "./EncounterPicker";
 import MetricPicker from "./MetricPicker";

--- a/src/lib/Params.ts
+++ b/src/lib/Params.ts
@@ -1,8 +1,6 @@
 import { ReadonlyURLSearchParams } from "next/navigation";
-
 import { type ItemFilterConfig } from "^/components/ItemPicker/ItemFilter";
 import { type TalentFilterConfig } from "^/components/TalentPicker/TalentFilter";
-
 import { MalformedUrlParameterError } from "./Errors";
 
 interface ParamTypeMeta {
@@ -162,9 +160,7 @@ export type ParsedParams = {
 
 export function parseParams(
     params:
-        | URLSearchParams
-        | ReadonlyURLSearchParams
-        | { [key: string]: string },
+        URLSearchParams | ReadonlyURLSearchParams | { [key: string]: string },
 ): ParsedParams {
     const getParam =
         params instanceof URLSearchParams ||

--- a/src/lib/raidbots/getLiteTalentTrees.ts
+++ b/src/lib/raidbots/getLiteTalentTrees.ts
@@ -1,5 +1,4 @@
 import { unstable_cache } from "next/cache";
-
 import { getTalentTrees } from "./getTalentTrees";
 import { type Scope } from "./scope";
 import {

--- a/src/lib/useParsedParams.ts
+++ b/src/lib/useParsedParams.ts
@@ -2,7 +2,6 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
-
 import { useNavigationTransition } from "./NavigationTransition";
 import { type ParsedParams, parseParams, toParams } from "./Params";
 import { removeNonCanonicalParams } from "./seo-utils";

--- a/src/lib/wcl/gameData.ts
+++ b/src/lib/wcl/gameData.ts
@@ -1,5 +1,4 @@
 import { cacheLife, cacheTag } from "next/cache";
-
 import { MalformedUrlParameterError } from "../Errors";
 import type { Klass, WclClass } from "./classes";
 import type { Region } from "./regions";

--- a/src/lib/wcl/rankings.ts
+++ b/src/lib/wcl/rankings.ts
@@ -1,9 +1,7 @@
 import { cacheLife, cacheTag } from "next/cache";
 import { cache } from "react";
-
 import { type ItemFilterConfig } from "^/components/ItemPicker/ItemFilter";
 import { type TalentFilterConfig } from "^/components/TalentPicker/TalentFilter";
-
 import { MalformedUrlParameterError, UnsupportedQueryError } from "../Errors";
 import { getClass, getGameData } from "./gameData";
 import { wclFetch } from "./wclFetch";

--- a/src/lib/wcl/wclFetch.ts
+++ b/src/lib/wcl/wclFetch.ts
@@ -1,5 +1,4 @@
 import { cacheLife } from "next/cache";
-
 import { ApiAuthenticationError } from "../Errors";
 
 const ROOT = "https://www.warcraftlogs.com/";


### PR DESCRIPTION
## Summary

Straight revert of #213. Oxfmt as a second formatter wasn't earning its keep here - this codebase is small enough that Prettier's speed was never a real cost, and running two separate formatting tools (one via `eslint --fix`, one standalone) added more tooling surface than it saved.

- `eslint-plugin-prettier`'s `prettier/prettier` rule and `eslint-plugin-import-x`'s `import-x/order` rule go back to their `@obusk/eslint-config-next` defaults instead of being turned off in favor of Oxfmt.
- The standalone CSS/MD/YAML/JSON formatting step goes back to the Prettier CLI (`.prettierignore` restored for `pnpm-lock.yaml`).
- `.oxfmtrc.json` and `.vscode/extensions.json` (which recommended the Oxc extension and marked Prettier unwanted) are removed; `.vscode/settings.json` goes back to Prettier + ESLint formatting.
- `AGENTS.md`/`README.md` references follow. "Double quotes for strings" stays as documented since that already matches both the current codebase and Prettier's own default - reverting the prose to "Single quotes" (the pre-Oxfmt wording) would just be wrong now.
- The `src/` changes are the mechanical output of `eslint --fix` under the restored rules (mostly `import-x/order` relearning this project's blank-line-free import grouping, plus one Prettier-preferred line wrap in `Params.ts`), kept in its own commit and added to `.git-blame-ignore-revs` so it doesn't obscure real history.

## Test plan

- [x] `pnpm run lint` - clean
- [x] `pnpm run test` - 34/34 passing
- [x] `pnpm run build` - succeeds

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011itycLLMz5ceLp4o965uaR